### PR TITLE
Theoretically better unlag based on bose position restoring

### DIFF
--- a/rehlds/engine/r_studio.cpp
+++ b/rehlds/engine/r_studio.cpp
@@ -627,7 +627,11 @@ hull_t *R_StudioHull(model_t *pModel, float frame, int sequence, const vec_t *an
 	pstudiohdr = (studiohdr_t *)Mod_Extradata(pModel);
 
 	vec_t angles2[3] = { -angles[0], angles[1], angles[2] };
+#ifdef REHLDS_FIXES
+	SV_StudioSetupUnlagBones( pModel, frame, sequence, angles2, origin, pcontroller, pblending, -1, pEdict );
+#else
 	g_pSvBlendingAPI->SV_StudioSetupBones(pModel, frame, sequence, angles2, origin, pcontroller, pblending, -1, pEdict);
+#endif
 
 	mstudiobbox_t *pbbox = (mstudiobbox_t *)((char *)pstudiohdr + pstudiohdr->hitboxindex);
 	for (int i = 0; i < pstudiohdr->numhitboxes; i++)
@@ -874,6 +878,17 @@ void EXT_FUNC AnimationAutomove(const edict_t *pEdict, float flTime)
 void EXT_FUNC GetBonePosition(const edict_t *pEdict, int iBone, float *rgflOrigin, float *rgflAngles)
 {
 	pstudiohdr = (studiohdr_t *)Mod_Extradata(g_psv.models[pEdict->v.modelindex]);
+#ifdef REHLDS_FIXES
+	SV_StudioSetupUnlagBones( g_psv.models[pEdict->v.modelindex],
+		pEdict->v.frame,
+		pEdict->v.sequence,
+		pEdict->v.angles,
+		pEdict->v.origin,
+		pEdict->v.controller,
+		pEdict->v.blending,
+		iBone,
+		pEdict );
+#else
 	g_pSvBlendingAPI->SV_StudioSetupBones(
 		g_psv.models[pEdict->v.modelindex],
 		pEdict->v.frame,
@@ -885,6 +900,7 @@ void EXT_FUNC GetBonePosition(const edict_t *pEdict, int iBone, float *rgflOrigi
 		iBone,
 		pEdict
 	);
+#endif
 
 	if (rgflOrigin)
 	{
@@ -907,6 +923,20 @@ void EXT_FUNC GetAttachment(const edict_t *pEdict, int iAttachment, float *rgflO
 	pattachment = (mstudioattachment_t *)((char *)pstudiohdr + pstudiohdr->attachmentindex);
 	pattachment += iAttachment;
 
+#ifdef REHLDS_FIXES
+	SV_StudioSetupUnlagBones( 
+		g_psv.models[pEdict->v.modelindex],
+		pEdict->v.frame,
+		pEdict->v.sequence,
+		angles,
+		pEdict->v.origin,
+		pEdict->v.controller,
+		pEdict->v.blending,
+		pattachment->bone,
+		pEdict 
+	);
+#else
+
 	g_pSvBlendingAPI->SV_StudioSetupBones(
 		g_psv.models[pEdict->v.modelindex],
 		pEdict->v.frame,
@@ -918,6 +948,7 @@ void EXT_FUNC GetAttachment(const edict_t *pEdict, int iAttachment, float *rgflO
 		pattachment->bone,
 		pEdict
 	);
+#endif
 
 	if (rgflOrigin)
 		VectorTransform(pattachment->org, bonetransform[pattachment->bone], rgflOrigin);

--- a/rehlds/engine/server.h
+++ b/rehlds/engine/server.h
@@ -53,6 +53,7 @@ const int MAX_NAME   = 32;
 #include "pm_defs.h"
 #include "inst_baseline.h"
 #include "net_ws.h"
+#include "studio_rehlds.h"
 
 const int DEFAULT_SOUND_PACKET_VOLUME			= 255;
 const float DEFAULT_SOUND_PACKET_ATTENUATION	= 1.0f;
@@ -175,6 +176,16 @@ struct rehlds_server_t {
 #endif
 };
 
+#ifdef REHLDS_FIXES
+// a1batross: "bone position"-based unlag
+typedef struct client_bone_state_s
+{
+	bonetransform_t bonetransform;
+	float rotationmatrix[3][4];
+	qboolean valid;
+} client_bone_state_t;
+#endif // REHLDS_FIXES
+
 typedef struct client_frame_s
 {
 	double senttime;
@@ -182,6 +193,9 @@ typedef struct client_frame_s
 	clientdata_t clientdata;
 	weapon_data_t weapondata[64];
 	packet_entities_t entities;
+#ifdef REHLDS_FIXES // a1batross: "bone position"-based unlag
+	client_bone_state_t bonestate;
+#endif // REHLDS_FIXES
 } client_frame_t;
 
 typedef struct client_s

--- a/rehlds/engine/server.h
+++ b/rehlds/engine/server.h
@@ -182,6 +182,7 @@ typedef struct client_bone_state_s
 {
 	bonetransform_t bonetransform;
 	float rotationmatrix[3][4];
+	int numbones;
 	qboolean valid;
 } client_bone_state_t;
 #endif // REHLDS_FIXES

--- a/rehlds/engine/sv_main.cpp
+++ b/rehlds/engine/sv_main.cpp
@@ -7717,6 +7717,9 @@ void SV_Init(void)
 	Cvar_RegisterVariable(&sv_instancedbaseline);
 	Cvar_RegisterVariable(&sv_contact);
 	Cvar_RegisterVariable(&sv_unlag);
+#ifdef REHLDS_FIXES
+	Cvar_RegisterVariable(&sv_bone_unlag);
+#endif
 	Cvar_RegisterVariable(&sv_maxunlag);
 	Cvar_RegisterVariable(&sv_unlagpush);
 	Cvar_RegisterVariable(&sv_unlagsamples);

--- a/rehlds/engine/sv_user.cpp
+++ b/rehlds/engine/sv_user.cpp
@@ -2038,7 +2038,7 @@ void SV_SaveBoneState(client_t *_host_client, const edict_t *edict)
 	frame = &_host_client->frames[SV_UPDATE_MASK & (_host_client->netchan.outgoing_sequence)];
 	
 	// not a studio model
-	if( g_psv.models[i]->type != mod_studio )
+	if( g_psv.models[edict->v.modelindex]->type != mod_studio )
 	{
 		frame->bonestate.valid = false;
 		return;

--- a/rehlds/engine/sv_user.cpp
+++ b/rehlds/engine/sv_user.cpp
@@ -1159,7 +1159,7 @@ entity_state_t *SV_FindEntInPack(int index, packet_entities_t *pack)
 	return NULL;
 }
 
-#ifdef REHLDS_FIXES
+
 void VectorsAngles( const vec3_t forward, const vec3_t right, const vec3_t up, vec3_t angles )
 {
 	float	pitch, cpitch, yaw, roll;
@@ -1224,6 +1224,7 @@ static void LerpRotationMatrix(const float from[3][4], const float to[3][4], flo
 	out[2][3] = pos1[2];
 }
 
+#ifdef REHLDS_FIXES
 static client_bone_state_t SV_StudioUnlagSlerpBones(const client_bone_state_t *from, const client_bone_state_t *to, float s)
 {
 	client_bone_state_t ret;

--- a/rehlds/engine/sv_user.h
+++ b/rehlds/engine/sv_user.h
@@ -49,6 +49,9 @@ typedef struct sv_adjusted_positions_s
 	int deadflag;
 	vec3_t temp_org;
 	int temp_org_setflag;
+#ifdef REHLDS_FIXES
+	client_bone_state_t bonestate;
+#endif // REHLDS_FIXES
 } sv_adjusted_positions_t;
 
 typedef struct clc_func_s
@@ -71,6 +74,9 @@ extern cvar_t sv_footsteps;
 extern cvar_t sv_rollspeed;
 extern cvar_t sv_rollangle;
 extern cvar_t sv_unlag;
+#ifdef REHLDS_FIXES
+extern cvar_t sv_bone_unlag;
+#endif
 extern cvar_t sv_maxunlag;
 extern cvar_t sv_unlagpush;
 extern cvar_t sv_unlagsamples;
@@ -117,3 +123,10 @@ qboolean SV_SetPlayer(int idnum);
 void SV_ShowServerinfo_f(void);
 void SV_SendEnts_f(void);
 void SV_FullUpdate_f(void);
+
+#ifdef REHLDS_FIXES
+void SV_SaveBoneState( client_t *cl, const edict_t *edict );
+
+// "bone position"-based sv_unlag
+void SV_StudioSetupUnlagBones( model_t *pModel, float frame, int sequence, const vec_t *angles, const vec_t *origin, const unsigned char *pcontroller, const unsigned char *pblending, int iBone, const edict_t *edict );
+#endif // REHLDS_FIXES


### PR DESCRIPTION
How it (should) work?

The main idea is to remember client's bone position on each frame. It's intended to help with situation where one player is updated in real-time, but lagging second player not yet got this updates. Unlag fixes it only for player position(i.e. working when player is running) and does not restores any other states.

Example: 
Let's say we have a server with two players and they "see" each other at one frame lag.
* Frame[0]: 
  * Player[0]:
    * Physics is running.

* Frame[1]: 
  * Player[0]:
    * Physics is running.
  * Player[1]:
    * Player[1] is connected.
    * Physics is running.

* Frame[2]:
  * Player[0]:
    * Player is ducking, i.e. his head is a bit below.
    * Physics is running. 
  * Player[1]:
    * Player[1] shoots at Player[0] right to his head. Due to lag, Player[1] sees Player[0] as NOT ducking.
    * Physics is running. Bullet is traced.
    * WITH bone position history:
       * Player[0] origin restored at Frame[1] **AND** head hull position is restored at Frame[1] position.
    * WITHOUT bone position history:
       * Player[0] origin restored at Frame[1], **BUT** his bones are set up in Frame[2] position, because previous sequence is unknown.

Yes, this demonstrates only sequence changing(i.e. ducking) but due to unlag imperfection, there can be  more real life examples.

P.S. I did not tested this at all as I don't have any server and players. :)
P. P. S. Originally I thought to make this for Xash3D, but it would be faster to check this concept on bigger community.