### PR TITLE
Add GetDispatch hook

### DIFF
--- a/rehlds/engine/sys_dll.cpp
+++ b/rehlds/engine/sys_dll.cpp
@@ -678,6 +678,11 @@ qboolean EXT_FUNC Voice_SetClientListening(int iReceiver, int iSender, qboolean 
 
 DISPATCHFUNCTION GetDispatch(char *pname)
 {
+	return g_RehldsHookchains.m_GetDispatch.callChain(GetDispatch_Internal, pname);
+}
+
+DISPATCHFUNCTION GetDispatch_Internal(char* pname)
+{
 	int i;
 	DISPATCHFUNCTION pDispatch;
 

--- a/rehlds/engine/sys_dll.h
+++ b/rehlds/engine/sys_dll.h
@@ -115,6 +115,7 @@ NOBODY void GameSetBackground(qboolean bNewSetting);
 qboolean Voice_GetClientListening(int iReceiver, int iSender);
 qboolean Voice_SetClientListening(int iReceiver, int iSender, qboolean bListen);
 DISPATCHFUNCTION GetDispatch(char *pname);
+DISPATCHFUNCTION GetDispatch_Internal(char* pname);
 const char *FindAddressInTable(extensiondll_t *pDll, uint32 function);
 uint32 FindNameInTable(extensiondll_t *pDll, const char *pName);
 NOBODY const char *ConvertNameToLocalPlatform(const char *pchInName);

--- a/rehlds/public/rehlds/rehlds_api.h
+++ b/rehlds/public/rehlds/rehlds_api.h
@@ -37,7 +37,7 @@
 #include "pr_dlls.h"
 
 #define REHLDS_API_VERSION_MAJOR 3
-#define REHLDS_API_VERSION_MINOR 13
+#define REHLDS_API_VERSION_MINOR 14
 
 //Steam_NotifyClientConnect hook
 typedef IHookChain<qboolean, IGameClient*, const void*, unsigned int> IRehldsHook_Steam_NotifyClientConnect;

--- a/rehlds/public/rehlds/rehlds_api.h
+++ b/rehlds/public/rehlds/rehlds_api.h
@@ -259,6 +259,10 @@ typedef IVoidHookChainRegistry<const char *> IRehldsHookRegistry_SV_ClientPrintf
 typedef IHookChain<bool, edict_t*, edict_t*> IRehldsHook_SV_AllowPhysent;
 typedef IHookChainRegistry<bool, edict_t*, edict_t*> IRehldsHookRegistry_SV_AllowPhysent;
 
+//GetDispatch hook
+typedef IHookChain<DISPATCHFUNCTION, char*> IRehldsHook_GetDispatch;
+typedef IHookChainRegistry<DISPATCHFUNCTION, char*> IRehldsHookRegistry_GetDispatch;
+
 class IRehldsHookchains {
 public:
 	virtual ~IRehldsHookchains() { }
@@ -318,6 +322,7 @@ public:
 	virtual IRehldsHookRegistry_SV_AddResource* SV_AddResource() = 0;
 	virtual IRehldsHookRegistry_SV_ClientPrintf* SV_ClientPrintf() = 0;
 	virtual IRehldsHookRegistry_SV_AllowPhysent* SV_AllowPhysent() = 0;
+	virtual IRehldsHookRegistry_GetDispatch* GetDispatch() = 0;
 };
 
 struct RehldsFuncs_t {

--- a/rehlds/rehlds/rehlds_api_impl.cpp
+++ b/rehlds/rehlds/rehlds_api_impl.cpp
@@ -883,6 +883,10 @@ IRehldsHookRegistry_SV_AllowPhysent* CRehldsHookchains::SV_AllowPhysent() {
 	return &m_SV_AllowPhysent;
 }
 
+EXT_FUNC IRehldsHookRegistry_GetDispatch* CRehldsHookchains::GetDispatch() {
+	return &m_GetDispatch;
+}
+
 int EXT_FUNC CRehldsApi::GetMajorVersion()
 {
 	return REHLDS_API_VERSION_MAJOR;

--- a/rehlds/rehlds/rehlds_api_impl.h
+++ b/rehlds/rehlds/rehlds_api_impl.h
@@ -254,6 +254,10 @@ typedef IVoidHookChainRegistryImpl<const char*> CRehldsHookRegistry_SV_ClientPri
 typedef IHookChainImpl<bool, edict_t*, edict_t*> CRehldsHook_SV_AllowPhysent;
 typedef IHookChainRegistryImpl<bool, edict_t*, edict_t*> CRehldsHookRegistry_SV_AllowPhysent;
 
+//GetDispatch hook
+typedef IHookChainImpl<DISPATCHFUNCTION, char*> CRehldsHook_GetDispatch;
+typedef IHookChainRegistryImpl<DISPATCHFUNCTION, char*> CRehldsHookRegistry_GetDispatch;
+
 class CRehldsHookchains : public IRehldsHookchains {
 public:
 	CRehldsHookRegistry_Steam_NotifyClientConnect m_Steam_NotifyClientConnect;
@@ -311,6 +315,7 @@ public:
 	CRehldsHookRegistry_SV_AddResource m_SV_AddResource;
 	CRehldsHookRegistry_SV_ClientPrintf m_SV_ClientPrintf;
 	CRehldsHookRegistry_SV_AllowPhysent m_SV_AllowPhysent;
+	CRehldsHookRegistry_GetDispatch m_GetDispatch;
 
 public:
 	EXT_FUNC virtual IRehldsHookRegistry_Steam_NotifyClientConnect* Steam_NotifyClientConnect();
@@ -368,6 +373,7 @@ public:
 	EXT_FUNC virtual IRehldsHookRegistry_SV_AddResource* SV_AddResource();
 	EXT_FUNC virtual IRehldsHookRegistry_SV_ClientPrintf* SV_ClientPrintf();
 	EXT_FUNC virtual IRehldsHookRegistry_SV_AllowPhysent* SV_AllowPhysent();
+	EXT_FUNC virtual IRehldsHookRegistry_GetDispatch* GetDispatch();
 };
 
 extern CRehldsHookchains g_RehldsHookchains;


### PR DESCRIPTION
This PR adds a hook for `GetDispatch` function. It is used by [WeaponMod](https://github.com/tmp64/weaponmod/).

It additionally bumps the API version to 3.14~~159265~~. #951 also bumped the version in `rehlds/version/version.h` but I didn't. Let me know and I'll fix the commit.