### PR TITLE
Make the server sets Steamids to clients after the validation by Steam servers

### DIFF
--- a/rehlds/engine/host.cpp
+++ b/rehlds/engine/host.cpp
@@ -475,6 +475,9 @@ void SV_DropClient_internal(client_t *cl, qboolean crash, const char *string)
 
 		if (!cl->fakeclient)
 			Netchan_Transmit(&cl->netchan, i, final);
+
+		cl->network_userid.m_SteamIDValidated = 0;
+		host_client->network_userid.m_SteamIDValidated = 0;
 	}
 
 	connection_time = realtime - cl->netchan.connect_time;

--- a/rehlds/engine/sv_main.cpp
+++ b/rehlds/engine/sv_main.cpp
@@ -8411,13 +8411,13 @@ char* EXT_FUNC SV_GetIDString_internal(USERID_t *id)
 		{
 			Q_strncpy(idstr, "STEAM_ID_LAN", ARRAYSIZE(idstr) - 1);
 		}
-		else if (!id->m_SteamID)
+		else if (!id->m_SteamIDValidated)
 		{
 			Q_strncpy(idstr, "STEAM_ID_PENDING", ARRAYSIZE(idstr) - 1);
 		}
 		else
 		{
-			TSteamGlobalUserID steam2ID = Steam_Steam3IDtoSteam2(id->m_SteamID);
+			TSteamGlobalUserID steam2ID = Steam_Steam3IDtoSteam2(id->m_SteamIDValidated);
 			Q_snprintf(idstr, ARRAYSIZE(idstr) - 1, "STEAM_%u:%u:%u", steam2ID.m_SteamInstanceID, steam2ID.m_SteamLocalUserID.Split.High32bits, steam2ID.m_SteamLocalUserID.Split.Low32bits);
 		}
 		break;
@@ -8426,13 +8426,13 @@ char* EXT_FUNC SV_GetIDString_internal(USERID_t *id)
 		{
 			Q_strncpy(idstr, "VALVE_ID_LAN", ARRAYSIZE(idstr) - 1);
 		}
-		else if (!id->m_SteamID)
+		else if (!id->m_SteamIDValidated)
 		{
 			Q_strncpy(idstr, "VALVE_ID_PENDING", ARRAYSIZE(idstr) - 1);
 		}
 		else
 		{
-			TSteamGlobalUserID steam2ID = Steam_Steam3IDtoSteam2(id->m_SteamID);
+			TSteamGlobalUserID steam2ID = Steam_Steam3IDtoSteam2(id->m_SteamIDValidated);
 			Q_snprintf(idstr, ARRAYSIZE(idstr) - 1, "VALVE_%u:%u:%u", steam2ID.m_SteamInstanceID, steam2ID.m_SteamLocalUserID.Split.High32bits, steam2ID.m_SteamLocalUserID.Split.Low32bits);
 		}
 		break;

--- a/rehlds/engine/sv_main.cpp
+++ b/rehlds/engine/sv_main.cpp
@@ -2539,7 +2539,7 @@ void EXT_FUNC SV_ConnectClient_internal(void)
 	host_client->userinfo[MAX_INFO_STRING - 1] = 0;
 
 	SV_ExtractFromUserinfo(host_client);
-	Info_SetValueForStarKey(host_client->userinfo, "*sid", va("%lld", host_client->network_userid.m_SteamID), MAX_INFO_STRING);
+	Info_SetValueForStarKey(host_client->userinfo, "*sid", va("%lld", host_client->network_userid.m_SteamIDValidated), MAX_INFO_STRING);
 
 	host_client->datagram.flags = SIZEBUF_ALLOW_OVERFLOW;
 	host_client->datagram.data = (byte *)host_client->datagram_buf;

--- a/rehlds/engine/sv_steam3.cpp
+++ b/rehlds/engine/sv_steam3.cpp
@@ -156,7 +156,9 @@ void CSteam3Server::OnGSClientDenyHelper(client_t *cl, EDenyReason eDenyReason, 
 		break;
 
 	case k_EDenySteamValidationStalled:
-		if (m_bLanOnly)
+		if (!m_bLanOnly)
+			SV_DropClient(cl, 0, "STEAM verification failed");
+		else
 			cl->network_userid.m_SteamID = 1;
 		break;
 

--- a/rehlds/engine/sv_steam3.cpp
+++ b/rehlds/engine/sv_steam3.cpp
@@ -174,6 +174,12 @@ void CSteam3Server::OnGSClientApprove(GSClientApprove_t *pGSClientSteam2Accept)
 	if (!cl)
 		return;
 
+	cl->network_userid.m_SteamIDValidated = pGSClientSteam2Accept->m_SteamID.ConvertToUint64();
+	host_client->network_userid.m_SteamIDValidated = pGSClientSteam2Accept->m_SteamID.ConvertToUint64();
+
+	Info_SetValueForStarKey(cl->userinfo, "*sid", va("%lld", cl->network_userid.m_SteamIDValidated), MAX_INFO_STRING);
+	Info_SetValueForStarKey(host_client->userinfo, "*sid", va("%lld", host_client->network_userid.m_SteamIDValidated), MAX_INFO_STRING);
+
 	if (SV_FilterUser(&cl->network_userid))
 	{
 		char msg[256];

--- a/rehlds/public/rehlds/userid_rehlds.h
+++ b/rehlds/public/rehlds/userid_rehlds.h
@@ -42,5 +42,6 @@ typedef struct USERID_s
 {
 	int idtype;
 	uint64 m_SteamID;
+	uint64 m_SteamIDValidated;
 	unsigned int clientip;
 } USERID_t;

--- a/rehlds/rehlds/structSizeCheck.cpp
+++ b/rehlds/rehlds/structSizeCheck.cpp
@@ -13,8 +13,8 @@ void check_size() {
 
 
 void checkSizesStatic() {
-	CHECK_TYPE_SIZE(client_t, 0x5018, 0x4EF4);
-	CHECK_TYPE_SIZE(userfilter_t, 0x20, 0x18);
+	CHECK_TYPE_SIZE(client_t, 0x5020, 0x4EFC);
+	CHECK_TYPE_SIZE(userfilter_t, 0x28, 0x20);
 #ifndef REHLDS_FIXES
 	CHECK_TYPE_SIZE(CSteam3Server, 0x90, 0xA8);
 #endif

--- a/rehlds/unittests/struct_offsets_tests.cpp
+++ b/rehlds/unittests/struct_offsets_tests.cpp
@@ -23,8 +23,8 @@ TEST(StructOffsets, ReversingChecks, 5000)
 	CHECK_STRUCT_OFFSET(client_t, active, 0, 0);
 	CHECK_STRUCT_OFFSET(client_t, chokecount, 0x2540, 0x2430);
 	CHECK_STRUCT_OFFSET(client_t, datagram, 0x25C0, 0x24AC);
-	CHECK_STRUCT_OFFSET(client_t, m_VoiceStreams, 0x5000, 0x4EE0);
-	CHECK_STRUCT_OFFSET(client_t, m_lastvoicetime, 0x5008, 0x4EE8);
+	CHECK_STRUCT_OFFSET(client_t, m_VoiceStreams, 0x5008, 0x4EE8);
+	CHECK_STRUCT_OFFSET(client_t, m_lastvoicetime, 0x5010, 0x4EF0);
 	CHECK_STRUCT_OFFSET(client_t, datagram_buf, 0x25D4, 0x24C0);
 	CHECK_STRUCT_OFFSET(client_t, connection_started, 0x3578, 0x3460);
 


### PR DESCRIPTION
This pr fixes the Steam App Ownership Ticket hijacking/spoofing vulnerability and related exploits. Now the server will sets the steamid from the ticket only after the client connection has been validated by the Steam servers. Before this, the client will be assigned `STEAM_ID_PENDING` (sid 0).

In fact, the GoldSrc server followed similar logic before the Steamworks updates.