### PR TITLE
Implement API function "Host_Pause"

### DIFF
--- a/rehlds/engine/host_cmd.cpp
+++ b/rehlds/engine/host_cmd.cpp
@@ -2808,6 +2808,26 @@ void Host_Kill_f(void)
 	gEntityInterface.pfnClientKill(sv_player);
 }
 
+void EXT_FUNC Host_Pause_api(bool setPause)
+{
+	g_psv.paused = setPause;
+#ifdef REHLDS_FIXES
+	for (int i = 0; i < g_psvs.maxclients; i++)
+	{
+		if (g_psvs.clients[i].fakeclient)
+			continue;
+		if (!g_psvs.clients[i].connected)
+			continue;
+
+		MSG_WriteByte(&g_psvs.clients[i].netchan.message, svc_setpause);
+		MSG_WriteByte(&g_psvs.clients[i].netchan.message, g_psv.paused);
+	}
+#else // REHLDS_FIXES
+	MSG_WriteByte(&g_psv.reliable_datagram, svc_setpause);
+	MSG_WriteByte(&g_psv.reliable_datagram, g_psv.paused);
+#endif // REHLDS_FIXES
+}
+
 void Host_TogglePause_f(void)
 {
 	if (cmd_source == src_command)
@@ -2857,22 +2877,7 @@ void Host_Pause_f(void)
 	if (!pausable.value)
 		return;
 
-	g_psv.paused = TRUE;
-#ifdef REHLDS_FIXES
-	for (int i = 0; i < g_psvs.maxclients; i++)
-	{
-		if (g_psvs.clients[i].fakeclient)
-			continue;
-		if (!g_psvs.clients[i].connected)
-			continue;
-
-		MSG_WriteByte(&g_psvs.clients[i].netchan.message, svc_setpause);
-		MSG_WriteByte(&g_psvs.clients[i].netchan.message, g_psv.paused);
-	}
-#else // REHLDS_FIXES
-	MSG_WriteByte(&g_psv.reliable_datagram, svc_setpause);
-	MSG_WriteByte(&g_psv.reliable_datagram, g_psv.paused);
-#endif // REHLDS_FIXES
+	Host_Pause_api(true);
 }
 
 void Host_Unpause_f(void)
@@ -2888,22 +2893,7 @@ void Host_Unpause_f(void)
 	if (!pausable.value)
 		return;
 
-	g_psv.paused = FALSE;
-#ifdef REHLDS_FIXES
-	for (int i = 0; i < g_psvs.maxclients; i++)
-	{
-		if (g_psvs.clients[i].fakeclient)
-			continue;
-		if (!g_psvs.clients[i].connected)
-			continue;
-
-		MSG_WriteByte(&g_psvs.clients[i].netchan.message, svc_setpause);
-		MSG_WriteByte(&g_psvs.clients[i].netchan.message, g_psv.paused);
-	}
-#else // REHLDS_FIXES
-	MSG_WriteByte(&g_psv.reliable_datagram, svc_setpause);
-	MSG_WriteByte(&g_psv.reliable_datagram, g_psv.paused);
-#endif // REHLDS_FIXES
+	Host_Pause_api(false);
 }
 
 void Host_Interp_f(void)

--- a/rehlds/engine/host_cmd.h
+++ b/rehlds/engine/host_cmd.h
@@ -169,6 +169,7 @@ void Host_Kill_f(void);
 void Host_TogglePause_f(void);
 void Host_Pause_f(void);
 void Host_Unpause_f(void);
+void Host_Pause_api(bool setPause);
 void Host_Interp_f(void);
 void Host_NextDemo(void);
 void Host_Startdemos_f(void);

--- a/rehlds/public/rehlds/rehlds_api.h
+++ b/rehlds/public/rehlds/rehlds_api.h
@@ -382,6 +382,7 @@ struct RehldsFuncs_t {
 	void(*RemoveExtDll)(void *hModule);
 	void(*RemoveCvarListener)(const char *var_name, cvar_callback_t func);
 	ENTITYINIT(*GetEntityInit)(char *pszClassName);
+	void(*Host_Pause)(bool setPause);
 
 	// Read functions
 	int(*MSG_ReadChar)();

--- a/rehlds/rehlds/rehlds_api_impl.cpp
+++ b/rehlds/rehlds/rehlds_api_impl.cpp
@@ -518,6 +518,7 @@ RehldsFuncs_t g_RehldsApiFuncs =
 	&RemoveExtDll_api,
 	&RemoveCvarListener_api,
 	&GetEntityInit_api,
+	&Host_Pause_api,
 	&MSG_ReadChar_api,
 	&MSG_ReadByte_api,
 	&MSG_ReadLong_api,


### PR DESCRIPTION
If need to pause, do not need to set `pausable` to `1` and then make client execute `pause` command anymore.
This stuff make pause easier and fix some clients may block `pause` commands sent by the server.