### PR TITLE
Added codesign and resources

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,11 @@ jobs:
           msbuild ${{ env.solution }} -p:Configuration="${{ env.buildRelease }}" /t:Clean,Build /p:Platform=${{ env.buildPlatform }} /p:PlatformToolset=v140_xp /p:XPDeprecationWarning=false
           msbuild ${{ env.solution }} -p:Configuration="${{ env.buildReleasePlay }}" /t:Clean,Build /p:Platform=${{ env.buildPlatform }} /p:PlatformToolset=v140_xp /p:XPDeprecationWarning=false
 
+      - name: Get rcedit from chocolatey
+        run: |
+          choco install rcedit -y
+        shell: "pwsh"
+
       - name: Move files
         run: |
           mkdir publish\debug
@@ -70,6 +75,39 @@ jobs:
           move msvc\${{ env.buildRelease }}\filesystem_stdio.pdb publish\debug\filesystem_stdio.pdb
           move msvc\${{ env.buildRelease }}\director.pdb publish\debug\director.pdb
 
+      # TODO: Set version to exe dynamicly: 0.0.0.0 to normal version such as at linux
+      - name: Edit resources at windows binaries
+        run: |
+         rcedit ${{ github.workspace }}/publish\bin\win32\hlds.exe --set-version-string ProductName "ReHLDS" --set-file-version "0.0.0.0" --set-product-version "0.0.0.0" --set-version-string FileDescription "The Half-Life Dedicated Server, Commit: $env:GITHUB_SHA" --set-version-string "Comments" "Commit: $env:GITHUB_SHA" --set-version-string CompanyName "ReHLDS Dev Team" --set-version-string LegalCopyright "Copyright 2025 Valve, ReHLDS DevTeam"
+         rcedit ${{ github.workspace }}/publish\bin\win32\hltv.exe --set-version-string ProductName "ReHLTV" --set-file-version "0.0.0.0" --set-product-version "0.0.0.0" --set-version-string FileDescription "The Half-Life TV, Commit: $env:GITHUB_SHA" --set-version-string "Comments" "Commit: $env:GITHUB_SHA" --set-version-string CompanyName "ReHLDS Dev Team" --set-version-string LegalCopyright "Copyright 2025 Valve, ReHLDS DevTeam"
+         rcedit ${{ github.workspace }}/publish\tests\swds.dll --set-version-string ProductName "swds.dll" --set-file-version "0.0.0.0" --set-product-version "0.0.0.0" --set-version-string FileDescription "A dll used by Steamworks Dedicated Servers, Commit: $env:GITHUB_SHA" --set-version-string "Comments" "Commit: $env:GITHUB_SHA" --set-version-string CompanyName "ReHLDS Dev Team" --set-version-string LegalCopyright "Copyright 2025 Valve, ReHLDS DevTeam" --set-icon rehlds/dedicated/msvc/icon.ico
+         rcedit ${{ github.workspace }}/publish\bin\win32\swds.dll --set-version-string ProductName "swds.dll" --set-file-version "0.0.0.0" --set-product-version "0.0.0.0" --set-version-string FileDescription "A ddll used by Steamworks Dedicated Servers, Commit: $env:GITHUB_SHA" --set-version-string "Comments" "Commit: $env:GITHUB_SHA" --set-version-string CompanyName "ReHLDS Dev Team" --set-version-string LegalCopyright "Copyright 2025 Valve, ReHLDS DevTeam" --set-icon rehlds/dedicated/msvc/icon.ico
+         rcedit ${{ github.workspace }}/publish\bin\win32\core.dll --set-version-string ProductName "core.dll" --set-file-version "0.0.0.0" --set-product-version "0.0.0.0" --set-version-string FileDescription " A dll, it is a core of game engine, Commit: $env:GITHUB_SHA" --set-version-string "Comments" "Commit: $env:GITHUB_SHA" --set-version-string CompanyName "ReHLDS Dev Team" --set-version-string LegalCopyright "Copyright 2025 Valve, ReHLDS DevTeam" --set-icon rehlds/dedicated/msvc/icon.ico
+         rcedit ${{ github.workspace }}/publish\bin\win32\proxy.dll --set-version-string ProductName "proxy.dll" --set-file-version "0.0.0.0" --set-product-version "0.0.0.0" --set-version-string FileDescription "A dll for proxying network connections, Commit: $env:GITHUB_SHA" --set-version-string "Comments" "Commit: $env:GITHUB_SHA" --set-version-string CompanyName "ReHLDS Dev Team" --set-version-string LegalCopyright "Copyright 2025 Valve, ReHLDS DevTeam" --set-icon rehlds/dedicated/msvc/icon.ico
+         rcedit ${{ github.workspace }}/publish\bin\win32\demoplayer.dll --set-version-string ProductName "demoplayer.dll" --set-file-version "0.0.0.0" --set-product-version "0.0.0.0" --set-version-string FileDescription "A dll for demoplayer functionality, Commit: $env:GITHUB_SHA" --set-version-string "Comments" "Commit: $env:GITHUB_SHA" --set-version-string CompanyName "ReHLDS Dev Team" --set-version-string LegalCopyright "Copyright 2025 Valve, ReHLDS DevTeam" --set-icon rehlds/dedicated/msvc/icon.ico
+         rcedit ${{ github.workspace }}/publish\bin\win32\filesystem_stdio.dll --set-version-string ProductName "filesystem_stdio.dll" --set-file-version "0.0.0.0" --set-product-version "0.0.0.0" --set-version-string FileDescription "A dll that manages file input/output operations, Commit: $env:GITHUB_SHA" --set-version-string "Comments" "Commit: $env:GITHUB_SHA" --set-version-string CompanyName "ReHLDS Dev Team" --set-version-string LegalCopyright "Copyright 2025 Valve, ReHLDS DevTeam" --set-icon rehlds/dedicated/msvc/icon.ico
+         rcedit ${{ github.workspace }}/publish\bin\win32\valve\dlls\director.dll --set-version-string ProductName "director.dll" --set-file-version "0.0.0.0" --set-product-version "0.0.0.0" --set-version-string FileDescription "A dll used for Director functionality in Half-Life 1, Commit: $env:GITHUB_SHA" --set-version-string "Comments" "Commit: $env:GITHUB_SHA" --set-version-string CompanyName "ReHLDS Dev Team" --set-version-string LegalCopyright "Copyright 2025 Valve, ReHLDS DevTeam" --set-icon rehlds/dedicated/msvc/icon.ico
+        shell: "pwsh"
+
+      - name: Import PFX and sign
+        env:
+          REHLDS_KEY_PFX_PASS: ${{ secrets.REHLDS_KEY_PFX_PASS}}
+        run: |
+               $pfxBase64 = "${{ secrets.REHLDS_KEY_PFX_B64 }}"
+               [IO.File]::WriteAllBytes("${{ github.workspace }}\signing-cert.pfx", [Convert]::FromBase64String($pfxBase64))
+               certutil -f -p "${{ secrets.REHLDS_KEY_PFX_PASS }}" -importPFX "${{ github.workspace }}\signing-cert.pfx"
+               & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}/publish\bin\win32\hlds.exe
+               & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "reHLTV" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}/publish\bin\win32\hltv.exe
+               & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - swds.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}/publish\tests\swds.dll
+               & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - swds.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}/publish\bin\win32\swds.dll
+               & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - core.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}/publish\bin\win32\core.dll
+               & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - proxy.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}/publish\bin\win32\proxy.dll
+               & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - demoplayer.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}/publish\bin\win32\demoplayer.dll
+               & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - filesystem_stdio.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}/publish\bin\win32\filesystem_stdio.dll
+               & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - director.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}/publish\bin\win32\valve\dlls\director.dll
+               Remove-Item -Recurse -Force "${{ github.workspace }}\signing-cert.pfx"
+        shell: "pwsh"
+
       - name: Deploy artifacts
         uses: actions/upload-artifact@v4
         with:
@@ -78,7 +116,7 @@ jobs:
 
   testdemos:
     name: 'Test demos'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container: rehldsorg/testdemos:latest
     needs: [windows]
     defaults:
@@ -116,7 +154,7 @@ jobs:
 
   linux:
     name: 'Linux'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     container: debian:11-slim
 
     steps:
@@ -135,6 +173,48 @@ jobs:
             libc6-dev libc6-dev-i386 \
             git cmake rsync \
             g++ gcc
+
+      - name: GPG Import
+        run: |
+          echo "${{ secrets.REHLDS_PUB_ASC }}" > "${{ secrets.REHLDS_PUB_ASC_FILE }}"
+          echo "${{ secrets.REHLDS_KEY_ASC }}" > "${{ secrets.REHLDS_KEY_ASC_FILE }}"
+
+          # Import the public key
+          gpg --batch --yes --import "${{ secrets.REHLDS_PUB_ASC_FILE }}"
+          if [[ $? -ne 0 ]]; then
+            echo "Error: Failed to import the public key"
+            exit 1
+          fi
+          
+          # Import the private key
+          gpg --batch --yes --import "${{ secrets.REHLDS_KEY_ASC_FILE }}"
+          if [[ $? -ne 0 ]]; then
+            echo "Error: Failed to import the private key"
+            exit 2
+          fi
+          
+          # Extract the fingerprint of the imported public key
+          REHLDS_LINUX_FINGERPRINT=$(gpg --list-keys --with-colons | grep '^fpr' | head -n 1 | cut -d: -f10)
+          
+          # Check if the fingerprint was extracted
+          if [[ -z "$REHLDS_LINUX_FINGERPRINT" ]]; then
+            echo "Error: Failed to extract the fingerprint of the key"
+            exit 3
+          fi
+          
+          # Set the trust level for the key
+          echo "$REHLDS_LINUX_FINGERPRINT:6:" | gpg --batch --import-ownertrust
+          if [ $? -ne 0 ]; then
+            echo "Error: Failed to set trust for the key $REHLDS_LINUX_FINGERPRINT"
+            exit 4
+          fi
+          
+          echo "Key $REHLDS_LINUX_FINGERPRINT successfully imported and trusted"
+          gpg --list-keys
+
+          #export for global use
+          echo "REHLDS_LINUX_FINGERPRINT=$REHLDS_LINUX_FINGERPRINT" >> $GITHUB_ENV
+        shell: bash
 
       - name: Build and Run unittests
         run: |
@@ -186,6 +266,40 @@ jobs:
           mv build/rehlds/HLTV/Director/director.so publish/bin/linux32/valve/dlls/director.so
           mv build/rehlds/filesystem/FileSystem_Stdio/filesystem_stdio.so publish/bin/linux32/filesystem_stdio.so
 
+      - name: Find and Sign Files
+        run: |
+
+          # Define directory containing files
+          TARGET_DIR="publish/bin"
+
+          # Find and sign each file
+          find "$TARGET_DIR" -type f -name "*" | while read -r FILE; do
+            echo "Signing $FILE..."
+            gpg --batch --yes --detach-sign --armor -u "$REHLDS_LINUX_FINGERPRINT" "$FILE"
+            if [ $? -ne 0 ]; then
+              echo "Error: Failed to sign $FILE"
+              exit 4
+            fi
+            echo "$FILE signed successfully."
+          done
+        shell: bash
+
+      - name: Verify Signatures
+        run: |
+
+          # Verify the generated signatures
+          TARGET_DIR="publish/bin"
+          find "$TARGET_DIR" -type f -not -name "*.asc" | while read -r FILE; do
+            echo "Verifying signature for $FILE..."
+            gpg --verify "$FILE.asc" "$FILE"
+            if [ $? -ne 0 ]; then
+              echo "Error: Signature verification failed for $FILE"
+              exit 5
+            fi
+            echo "Signature for $FILE is valid."
+          done
+        shell: bash
+
       - name: Run GLIBC/ABI version compat test
         run: |
           binaries=(
@@ -213,7 +327,7 @@ jobs:
 
   publish:
     name: 'Publish'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: [windows, testdemos, linux]
 
     steps:
@@ -241,15 +355,63 @@ jobs:
           fi
           rm -f appversion.h
 
-      - name: Packaging bin/dbg
+      - name: Final signing and Packaging bin/dbg
         id: packaging-job
         if: |
           github.event_name == 'release' &&
           github.event.action == 'published' &&
           startsWith(github.ref, 'refs/tags/')
         run: |
+
+          # new runner, niw signs
+          echo "${{ secrets.REHLDS_PUB_ASC }}" > "${{ secrets.REHLDS_PUB_ASC_FILE }}"
+          echo "${{ secrets.REHLDS_KEY_ASC }}" > "${{ secrets.REHLDS_KEY_ASC_FILE }}"
+          gpg --batch --yes --import "${{ secrets.REHLDS_PUB_ASC_FILE }}"
+          gpg --batch --yes --import "${{ secrets.REHLDS_KEY_ASC_FILE }}"
+          REHLDS_LINUX_FINGERPRINT=$(gpg --list-keys --with-colons | grep '^fpr' | head -n 1 | cut -d: -f10)
+          echo "$REHLDS_LINUX_FINGERPRINT:6:" | gpg --batch --import-ownertrust
+          echo "REHLDS_LINUX_FINGERPRINT=$REHLDS_LINUX_FINGERPRINT" >> $GITHUB_ENV
+
+          # Find and sign each win32 files, linux files already signed
+          find ./bin/win32 -type f -name "*" | while read -r FILE; do
+            echo "Signing $FILE..."
+            gpg --batch --yes --detach-sign --armor -u "$REHLDS_LINUX_FINGERPRINT" "$FILE"
+            if [ $? -ne 0 ]; then
+              echo "Error: Failed to sign $FILE"
+              exit 1
+            fi
+            echo "$FILE signed successfully."
+          done
+          sign_file() {
+            local file=$1
+            gpg --batch --yes --detach-sign --armor -u "$REHLDS_LINUX_FINGERPRINT" "$file"
+            if [ $? -ne 0 ]; then
+              echo "Error: Failed to sign $file"
+              exit 2
+            fi
+            echo "$file signed successfully."
+          }
+          
+          # Pack and sign final archive
           7z a -tzip rehlds-bin-${{ env.APP_VERSION }}.zip bin/ hlsdk/
+          sign_file "rehlds-bin-${{ env.APP_VERSION }}.zip"
+
+          # Find and sign each PDB files
+          find ./debug -type f -name "*" | while read -r FILE; do
+            echo "Signing $FILE..."
+            gpg --batch --yes --detach-sign --armor -u "$REHLDS_LINUX_FINGERPRINT" "$FILE"
+            if [ $? -ne 0 ]; then
+              echo "Error: Failed to sign $FILE"
+              exit 3
+            fi
+            echo "$FILE signed successfully."
+          done
+          
+          # Pack and sign final archive
           7z a -t7z -m0=lzma2 -mx=9 -mfb=64 -aoa rehlds-dbg-${{ env.APP_VERSION }}.7z debug/
+          sign_file "rehlds-dbg-${{ env.APP_VERSION }}.7z"
+
+        shell: bash
 
       - name: Publish artifacts
         uses: softprops/action-gh-release@v2
@@ -261,5 +423,6 @@ jobs:
           files: |
             *.zip
             *.7z
+            *.asc
         env:
           GITHUB_TOKEN: ${{ secrets.API_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,15 +78,15 @@ jobs:
       # TODO: Set version to exe dynamicly: 0.0.0.0 to normal version such as at linux
       - name: Edit resources at windows binaries
         run: |
-         rcedit ${{ github.workspace }}/publish\bin\win32\hlds.exe --set-version-string ProductName "ReHLDS" --set-file-version "0.0.0.0" --set-product-version "0.0.0.0" --set-version-string FileDescription "The Half-Life Dedicated Server, Commit: $env:GITHUB_SHA" --set-version-string "Comments" "Commit: $env:GITHUB_SHA" --set-version-string CompanyName "ReHLDS Dev Team" --set-version-string LegalCopyright "Copyright 2025 Valve, ReHLDS DevTeam"
-         rcedit ${{ github.workspace }}/publish\bin\win32\hltv.exe --set-version-string ProductName "ReHLTV" --set-file-version "0.0.0.0" --set-product-version "0.0.0.0" --set-version-string FileDescription "The Half-Life TV, Commit: $env:GITHUB_SHA" --set-version-string "Comments" "Commit: $env:GITHUB_SHA" --set-version-string CompanyName "ReHLDS Dev Team" --set-version-string LegalCopyright "Copyright 2025 Valve, ReHLDS DevTeam"
-         rcedit ${{ github.workspace }}/publish\tests\swds.dll --set-version-string ProductName "swds.dll" --set-file-version "0.0.0.0" --set-product-version "0.0.0.0" --set-version-string FileDescription "A dll used by Steamworks Dedicated Servers, Commit: $env:GITHUB_SHA" --set-version-string "Comments" "Commit: $env:GITHUB_SHA" --set-version-string CompanyName "ReHLDS Dev Team" --set-version-string LegalCopyright "Copyright 2025 Valve, ReHLDS DevTeam" --set-icon rehlds/dedicated/msvc/icon.ico
-         rcedit ${{ github.workspace }}/publish\bin\win32\swds.dll --set-version-string ProductName "swds.dll" --set-file-version "0.0.0.0" --set-product-version "0.0.0.0" --set-version-string FileDescription "A ddll used by Steamworks Dedicated Servers, Commit: $env:GITHUB_SHA" --set-version-string "Comments" "Commit: $env:GITHUB_SHA" --set-version-string CompanyName "ReHLDS Dev Team" --set-version-string LegalCopyright "Copyright 2025 Valve, ReHLDS DevTeam" --set-icon rehlds/dedicated/msvc/icon.ico
-         rcedit ${{ github.workspace }}/publish\bin\win32\core.dll --set-version-string ProductName "core.dll" --set-file-version "0.0.0.0" --set-product-version "0.0.0.0" --set-version-string FileDescription " A dll, it is a core of game engine, Commit: $env:GITHUB_SHA" --set-version-string "Comments" "Commit: $env:GITHUB_SHA" --set-version-string CompanyName "ReHLDS Dev Team" --set-version-string LegalCopyright "Copyright 2025 Valve, ReHLDS DevTeam" --set-icon rehlds/dedicated/msvc/icon.ico
-         rcedit ${{ github.workspace }}/publish\bin\win32\proxy.dll --set-version-string ProductName "proxy.dll" --set-file-version "0.0.0.0" --set-product-version "0.0.0.0" --set-version-string FileDescription "A dll for proxying network connections, Commit: $env:GITHUB_SHA" --set-version-string "Comments" "Commit: $env:GITHUB_SHA" --set-version-string CompanyName "ReHLDS Dev Team" --set-version-string LegalCopyright "Copyright 2025 Valve, ReHLDS DevTeam" --set-icon rehlds/dedicated/msvc/icon.ico
-         rcedit ${{ github.workspace }}/publish\bin\win32\demoplayer.dll --set-version-string ProductName "demoplayer.dll" --set-file-version "0.0.0.0" --set-product-version "0.0.0.0" --set-version-string FileDescription "A dll for demoplayer functionality, Commit: $env:GITHUB_SHA" --set-version-string "Comments" "Commit: $env:GITHUB_SHA" --set-version-string CompanyName "ReHLDS Dev Team" --set-version-string LegalCopyright "Copyright 2025 Valve, ReHLDS DevTeam" --set-icon rehlds/dedicated/msvc/icon.ico
-         rcedit ${{ github.workspace }}/publish\bin\win32\filesystem_stdio.dll --set-version-string ProductName "filesystem_stdio.dll" --set-file-version "0.0.0.0" --set-product-version "0.0.0.0" --set-version-string FileDescription "A dll that manages file input/output operations, Commit: $env:GITHUB_SHA" --set-version-string "Comments" "Commit: $env:GITHUB_SHA" --set-version-string CompanyName "ReHLDS Dev Team" --set-version-string LegalCopyright "Copyright 2025 Valve, ReHLDS DevTeam" --set-icon rehlds/dedicated/msvc/icon.ico
-         rcedit ${{ github.workspace }}/publish\bin\win32\valve\dlls\director.dll --set-version-string ProductName "director.dll" --set-file-version "0.0.0.0" --set-product-version "0.0.0.0" --set-version-string FileDescription "A dll used for Director functionality in Half-Life 1, Commit: $env:GITHUB_SHA" --set-version-string "Comments" "Commit: $env:GITHUB_SHA" --set-version-string CompanyName "ReHLDS Dev Team" --set-version-string LegalCopyright "Copyright 2025 Valve, ReHLDS DevTeam" --set-icon rehlds/dedicated/msvc/icon.ico
+         rcedit ${{ github.workspace }}\publish\bin\win32\hlds.exe --set-version-string ProductName "ReHLDS" --set-file-version "0.0.0.0" --set-product-version "0.0.0.0" --set-version-string FileDescription "The Half-Life Dedicated Server, Commit: $env:GITHUB_SHA" --set-version-string "Comments" "Commit: $env:GITHUB_SHA" --set-version-string CompanyName "ReHLDS Dev Team" --set-version-string LegalCopyright "Copyright 2025 Valve, ReHLDS DevTeam"
+         rcedit ${{ github.workspace }}\publish\bin\win32\hltv.exe --set-version-string ProductName "ReHLTV" --set-file-version "0.0.0.0" --set-product-version "0.0.0.0" --set-version-string FileDescription "The Half-Life TV, Commit: $env:GITHUB_SHA" --set-version-string "Comments" "Commit: $env:GITHUB_SHA" --set-version-string CompanyName "ReHLDS Dev Team" --set-version-string LegalCopyright "Copyright 2025 Valve, ReHLDS DevTeam"
+         rcedit ${{ github.workspace }}\publish\tests\swds.dll --set-version-string ProductName "swds.dll" --set-file-version "0.0.0.0" --set-product-version "0.0.0.0" --set-version-string FileDescription "A dll used by Steamworks Dedicated Servers, Commit: $env:GITHUB_SHA" --set-version-string "Comments" "Commit: $env:GITHUB_SHA" --set-version-string CompanyName "ReHLDS Dev Team" --set-version-string LegalCopyright "Copyright 2025 Valve, ReHLDS DevTeam" --set-icon rehlds/dedicated/msvc/icon.ico
+         rcedit ${{ github.workspace }}\publish\bin\win32\swds.dll --set-version-string ProductName "swds.dll" --set-file-version "0.0.0.0" --set-product-version "0.0.0.0" --set-version-string FileDescription "A ddll used by Steamworks Dedicated Servers, Commit: $env:GITHUB_SHA" --set-version-string "Comments" "Commit: $env:GITHUB_SHA" --set-version-string CompanyName "ReHLDS Dev Team" --set-version-string LegalCopyright "Copyright 2025 Valve, ReHLDS DevTeam" --set-icon rehlds/dedicated/msvc/icon.ico
+         rcedit ${{ github.workspace }}\publish\bin\win32\core.dll --set-version-string ProductName "core.dll" --set-file-version "0.0.0.0" --set-product-version "0.0.0.0" --set-version-string FileDescription " A dll, it is a core of game engine, Commit: $env:GITHUB_SHA" --set-version-string "Comments" "Commit: $env:GITHUB_SHA" --set-version-string CompanyName "ReHLDS Dev Team" --set-version-string LegalCopyright "Copyright 2025 Valve, ReHLDS DevTeam" --set-icon rehlds/dedicated/msvc/icon.ico
+         rcedit ${{ github.workspace }}\publish\bin\win32\proxy.dll --set-version-string ProductName "proxy.dll" --set-file-version "0.0.0.0" --set-product-version "0.0.0.0" --set-version-string FileDescription "A dll for proxying network connections, Commit: $env:GITHUB_SHA" --set-version-string "Comments" "Commit: $env:GITHUB_SHA" --set-version-string CompanyName "ReHLDS Dev Team" --set-version-string LegalCopyright "Copyright 2025 Valve, ReHLDS DevTeam" --set-icon rehlds/dedicated/msvc/icon.ico
+         rcedit ${{ github.workspace }}\publish\bin\win32\demoplayer.dll --set-version-string ProductName "demoplayer.dll" --set-file-version "0.0.0.0" --set-product-version "0.0.0.0" --set-version-string FileDescription "A dll for demoplayer functionality, Commit: $env:GITHUB_SHA" --set-version-string "Comments" "Commit: $env:GITHUB_SHA" --set-version-string CompanyName "ReHLDS Dev Team" --set-version-string LegalCopyright "Copyright 2025 Valve, ReHLDS DevTeam" --set-icon rehlds/dedicated/msvc/icon.ico
+         rcedit ${{ github.workspace }}\publish\bin\win32\filesystem_stdio.dll --set-version-string ProductName "filesystem_stdio.dll" --set-file-version "0.0.0.0" --set-product-version "0.0.0.0" --set-version-string FileDescription "A dll that manages file input/output operations, Commit: $env:GITHUB_SHA" --set-version-string "Comments" "Commit: $env:GITHUB_SHA" --set-version-string CompanyName "ReHLDS Dev Team" --set-version-string LegalCopyright "Copyright 2025 Valve, ReHLDS DevTeam" --set-icon rehlds/dedicated/msvc/icon.ico
+         rcedit ${{ github.workspace }}\publish\bin\win32\valve\dlls\director.dll --set-version-string ProductName "director.dll" --set-file-version "0.0.0.0" --set-product-version "0.0.0.0" --set-version-string FileDescription "A dll used for Director functionality in Half-Life 1, Commit: $env:GITHUB_SHA" --set-version-string "Comments" "Commit: $env:GITHUB_SHA" --set-version-string CompanyName "ReHLDS Dev Team" --set-version-string LegalCopyright "Copyright 2025 Valve, ReHLDS DevTeam" --set-icon rehlds/dedicated/msvc/icon.ico
         shell: "pwsh"
 
       - name: Import PFX and sign
@@ -96,15 +96,15 @@ jobs:
                $pfxBase64 = "${{ secrets.REHLDS_KEY_PFX_B64 }}"
                [IO.File]::WriteAllBytes("${{ github.workspace }}\signing-cert.pfx", [Convert]::FromBase64String($pfxBase64))
                certutil -f -p "${{ secrets.REHLDS_KEY_PFX_PASS }}" -importPFX "${{ github.workspace }}\signing-cert.pfx"
-               & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}/publish\bin\win32\hlds.exe
-               & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "reHLTV" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}/publish\bin\win32\hltv.exe
-               & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - swds.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}/publish\tests\swds.dll
-               & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - swds.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}/publish\bin\win32\swds.dll
-               & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - core.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}/publish\bin\win32\core.dll
-               & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - proxy.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}/publish\bin\win32\proxy.dll
-               & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - demoplayer.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}/publish\bin\win32\demoplayer.dll
-               & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - filesystem_stdio.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}/publish\bin\win32\filesystem_stdio.dll
-               & 'C:/Program Files (x86)/Windows Kits/10/bin/10.0.22621.0/x86/signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - director.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}/publish\bin\win32\valve\dlls\director.dll
+               & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}\publish\bin\win32\hlds.exe
+               & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "reHLTV" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}\publish\bin\win32\hltv.exe
+               & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - swds.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}\publish\tests\swds.dll
+               & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - swds.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}\publish\bin\win32\swds.dll
+               & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - core.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}\publish\bin\win32\core.dll
+               & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - proxy.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}\publish\bin\win32\proxy.dll
+               & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - demoplayer.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}\publish\bin\win32\demoplayer.dll
+               & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - filesystem_stdio.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}\publish\bin\win32\filesystem_stdio.dll
+               & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - director.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}\publish\bin\win32\valve\dlls\director.dll
                Remove-Item -Recurse -Force "${{ github.workspace }}\signing-cert.pfx"
         shell: "pwsh"
 
@@ -266,40 +266,6 @@ jobs:
           mv build/rehlds/HLTV/Director/director.so publish/bin/linux32/valve/dlls/director.so
           mv build/rehlds/filesystem/FileSystem_Stdio/filesystem_stdio.so publish/bin/linux32/filesystem_stdio.so
 
-      - name: Find and Sign Files
-        run: |
-
-          # Define directory containing files
-          TARGET_DIR="publish/bin"
-
-          # Find and sign each file
-          find "$TARGET_DIR" -type f -name "*" | while read -r FILE; do
-            echo "Signing $FILE..."
-            gpg --batch --yes --detach-sign --armor -u "$REHLDS_LINUX_FINGERPRINT" "$FILE"
-            if [ $? -ne 0 ]; then
-              echo "Error: Failed to sign $FILE"
-              exit 4
-            fi
-            echo "$FILE signed successfully."
-          done
-        shell: bash
-
-      - name: Verify Signatures
-        run: |
-
-          # Verify the generated signatures
-          TARGET_DIR="publish/bin"
-          find "$TARGET_DIR" -type f -not -name "*.asc" | while read -r FILE; do
-            echo "Verifying signature for $FILE..."
-            gpg --verify "$FILE.asc" "$FILE"
-            if [ $? -ne 0 ]; then
-              echo "Error: Signature verification failed for $FILE"
-              exit 5
-            fi
-            echo "Signature for $FILE is valid."
-          done
-        shell: bash
-
       - name: Run GLIBC/ABI version compat test
         run: |
           binaries=(
@@ -372,16 +338,6 @@ jobs:
           echo "$REHLDS_LINUX_FINGERPRINT:6:" | gpg --batch --import-ownertrust
           echo "REHLDS_LINUX_FINGERPRINT=$REHLDS_LINUX_FINGERPRINT" >> $GITHUB_ENV
 
-          # Find and sign each win32 files, linux files already signed
-          find ./bin/win32 -type f -name "*" | while read -r FILE; do
-            echo "Signing $FILE..."
-            gpg --batch --yes --detach-sign --armor -u "$REHLDS_LINUX_FINGERPRINT" "$FILE"
-            if [ $? -ne 0 ]; then
-              echo "Error: Failed to sign $FILE"
-              exit 1
-            fi
-            echo "$FILE signed successfully."
-          done
           sign_file() {
             local file=$1
             gpg --batch --yes --detach-sign --armor -u "$REHLDS_LINUX_FINGERPRINT" "$file"
@@ -396,17 +352,6 @@ jobs:
           7z a -tzip rehlds-bin-${{ env.APP_VERSION }}.zip bin/ hlsdk/
           sign_file "rehlds-bin-${{ env.APP_VERSION }}.zip"
 
-          # Find and sign each PDB files
-          find ./debug -type f -name "*" | while read -r FILE; do
-            echo "Signing $FILE..."
-            gpg --batch --yes --detach-sign --armor -u "$REHLDS_LINUX_FINGERPRINT" "$FILE"
-            if [ $? -ne 0 ]; then
-              echo "Error: Failed to sign $FILE"
-              exit 3
-            fi
-            echo "$FILE signed successfully."
-          done
-          
           # Pack and sign final archive
           7z a -t7z -m0=lzma2 -mx=9 -mfb=64 -aoa rehlds-dbg-${{ env.APP_VERSION }}.7z debug/
           sign_file "rehlds-dbg-${{ env.APP_VERSION }}.7z"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,20 +91,20 @@ jobs:
 
       - name: Import PFX and sign
         env:
-          REHLDS_KEY_PFX_PASS: ${{ secrets.REHLDS_KEY_PFX_PASS}}
+          KEY_PFX_PASS: ${{ secrets.KEY_PFX_PASS}}
         run: |
-               $pfxBase64 = "${{ secrets.REHLDS_KEY_PFX_B64 }}"
+               $pfxBase64 = "${{ secrets.KEY_PFX_B64 }}"
                [IO.File]::WriteAllBytes("${{ github.workspace }}\signing-cert.pfx", [Convert]::FromBase64String($pfxBase64))
-               certutil -f -p "${{ secrets.REHLDS_KEY_PFX_PASS }}" -importPFX "${{ github.workspace }}\signing-cert.pfx"
-               & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}\publish\bin\win32\hlds.exe
-               & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "reHLTV" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}\publish\bin\win32\hltv.exe
-               & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - swds.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}\publish\tests\swds.dll
-               & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - swds.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}\publish\bin\win32\swds.dll
-               & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - core.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}\publish\bin\win32\core.dll
-               & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - proxy.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}\publish\bin\win32\proxy.dll
-               & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - demoplayer.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}\publish\bin\win32\demoplayer.dll
-               & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - filesystem_stdio.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}\publish\bin\win32\filesystem_stdio.dll
-               & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:REHLDS_KEY_PFX_PASS /d "ReHLDS - director.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}\publish\bin\win32\valve\dlls\director.dll
+               certutil -f -p "${{ secrets.KEY_PFX_PASS }}" -importPFX "${{ github.workspace }}\signing-cert.pfx"
+               & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:KEY_PFX_PASS /d "ReHLDS" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}\publish\bin\win32\hlds.exe
+               & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:KEY_PFX_PASS /d "reHLTV" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}\publish\bin\win32\hltv.exe
+               & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:KEY_PFX_PASS /d "ReHLDS - swds.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}\publish\tests\swds.dll
+               & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:KEY_PFX_PASS /d "ReHLDS - swds.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}\publish\bin\win32\swds.dll
+               & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:KEY_PFX_PASS /d "ReHLDS - core.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}\publish\bin\win32\core.dll
+               & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:KEY_PFX_PASS /d "ReHLDS - proxy.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}\publish\bin\win32\proxy.dll
+               & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:KEY_PFX_PASS /d "ReHLDS - demoplayer.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}\publish\bin\win32\demoplayer.dll
+               & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:KEY_PFX_PASS /d "ReHLDS - filesystem_stdio.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}\publish\bin\win32\filesystem_stdio.dll
+               & 'C:\Program Files (x86)\Windows Kits\10\bin\10.0.22621.0\x86\signtool.exe' sign /a /f "${{ github.workspace }}\signing-cert.pfx"  /p $env:KEY_PFX_PASS /d "ReHLDS - director.dll" /du "https://rehlds.dev/" /tr "http://timestamp.digicert.com" /td sha512 /fd sha512 /v ${{ github.workspace }}\publish\bin\win32\valve\dlls\director.dll
                Remove-Item -Recurse -Force "${{ github.workspace }}\signing-cert.pfx"
         shell: "pwsh"
 
@@ -176,44 +176,44 @@ jobs:
 
       - name: GPG Import
         run: |
-          echo "${{ secrets.REHLDS_PUB_ASC }}" > "${{ secrets.REHLDS_PUB_ASC_FILE }}"
-          echo "${{ secrets.REHLDS_KEY_ASC }}" > "${{ secrets.REHLDS_KEY_ASC_FILE }}"
+          echo "${{ secrets.PUB_ASC }}" > "${{ secrets.PUB_ASC_FILE }}"
+          echo "${{ secrets.KEY_ASC }}" > "${{ secrets.KEY_ASC_FILE }}"
 
           # Import the public key
-          gpg --batch --yes --import "${{ secrets.REHLDS_PUB_ASC_FILE }}"
+          gpg --batch --yes --import "${{ secrets.PUB_ASC_FILE }}"
           if [[ $? -ne 0 ]]; then
             echo "Error: Failed to import the public key"
             exit 1
           fi
           
           # Import the private key
-          gpg --batch --yes --import "${{ secrets.REHLDS_KEY_ASC_FILE }}"
+          gpg --batch --yes --import "${{ secrets.KEY_ASC_FILE }}"
           if [[ $? -ne 0 ]]; then
             echo "Error: Failed to import the private key"
             exit 2
           fi
           
           # Extract the fingerprint of the imported public key
-          REHLDS_LINUX_FINGERPRINT=$(gpg --list-keys --with-colons | grep '^fpr' | head -n 1 | cut -d: -f10)
+          GPG_LINUX_FINGERPRINT=$(gpg --list-keys --with-colons | grep '^fpr' | head -n 1 | cut -d: -f10)
           
           # Check if the fingerprint was extracted
-          if [[ -z "$REHLDS_LINUX_FINGERPRINT" ]]; then
+          if [[ -z "$GPG_LINUX_FINGERPRINT" ]]; then
             echo "Error: Failed to extract the fingerprint of the key"
             exit 3
           fi
           
           # Set the trust level for the key
-          echo "$REHLDS_LINUX_FINGERPRINT:6:" | gpg --batch --import-ownertrust
+          echo "$GPG_LINUX_FINGERPRINT:6:" | gpg --batch --import-ownertrust
           if [ $? -ne 0 ]; then
-            echo "Error: Failed to set trust for the key $REHLDS_LINUX_FINGERPRINT"
+            echo "Error: Failed to set trust for the key $GPG_LINUX_FINGERPRINT"
             exit 4
           fi
           
-          echo "Key $REHLDS_LINUX_FINGERPRINT successfully imported and trusted"
+          echo "Key $GPG_LINUX_FINGERPRINT successfully imported and trusted"
           gpg --list-keys
 
           #export for global use
-          echo "REHLDS_LINUX_FINGERPRINT=$REHLDS_LINUX_FINGERPRINT" >> $GITHUB_ENV
+          echo "GPG_LINUX_FINGERPRINT=$GPG_LINUX_FINGERPRINT" >> $GITHUB_ENV
         shell: bash
 
       - name: Build and Run unittests
@@ -330,17 +330,17 @@ jobs:
         run: |
 
           # new runner, niw signs
-          echo "${{ secrets.REHLDS_PUB_ASC }}" > "${{ secrets.REHLDS_PUB_ASC_FILE }}"
-          echo "${{ secrets.REHLDS_KEY_ASC }}" > "${{ secrets.REHLDS_KEY_ASC_FILE }}"
-          gpg --batch --yes --import "${{ secrets.REHLDS_PUB_ASC_FILE }}"
-          gpg --batch --yes --import "${{ secrets.REHLDS_KEY_ASC_FILE }}"
-          REHLDS_LINUX_FINGERPRINT=$(gpg --list-keys --with-colons | grep '^fpr' | head -n 1 | cut -d: -f10)
-          echo "$REHLDS_LINUX_FINGERPRINT:6:" | gpg --batch --import-ownertrust
-          echo "REHLDS_LINUX_FINGERPRINT=$REHLDS_LINUX_FINGERPRINT" >> $GITHUB_ENV
+          echo "${{ secrets.PUB_ASC }}" > "${{ secrets.PUB_ASC_FILE }}"
+          echo "${{ secrets.KEY_ASC }}" > "${{ secrets.KEY_ASC_FILE }}"
+          gpg --batch --yes --import "${{ secrets.PUB_ASC_FILE }}"
+          gpg --batch --yes --import "${{ secrets.KEY_ASC_FILE }}"
+          GPG_LINUX_FINGERPRINT=$(gpg --list-keys --with-colons | grep '^fpr' | head -n 1 | cut -d: -f10)
+          echo "$GPG_LINUX_FINGERPRINT:6:" | gpg --batch --import-ownertrust
+          echo "GPG_LINUX_FINGERPRINT=$GPG_LINUX_FINGERPRINT" >> $GITHUB_ENV
 
           sign_file() {
             local file=$1
-            gpg --batch --yes --detach-sign --armor -u "$REHLDS_LINUX_FINGERPRINT" "$file"
+            gpg --batch --yes --detach-sign --armor -u "$GPG_LINUX_FINGERPRINT" "$file"
             if [ $? -ne 0 ]; then
               echo "Error: Failed to sign $file"
               exit 2

--- a/README.md
+++ b/README.md
@@ -8,6 +8,15 @@ Along with reverse engineering, a lot of defects and (potential) bugs were found
 
 You can try playing on one of many servers that are using ReHLDS: [Game Tracker](http://www.gametracker.com/search/?search_by=server_variable&search_by2=sv_version)
 
+> [!TIP]
+> ReHLDS linux-releases now is signed via `GPG`, pubkey is: `63547829004f07716f7be4856c32c4282e60fb67` and could be found at [https://keyserver.ubuntu.com/](https://keyserver.ubuntu.com/pks/lookup?search=63547829004f07716f7be4856c32c4282e60fb67+&fingerprint=on&op=index).
+>
+> How to:
+> 1. [Download](https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x63547829004f07716f7be4856c32c4282e60fb67) `63547829004f07716f7be4856c32c4282e60fb67.asc` key
+> 2. Import: `gpg --import 63547829004f07716f7be4856c32c4282e60fb67.asc`
+> 3. Download release `archive` and `.asc` file.
+> 4. Verify: `gpg --verify some-rehlds.zip.asc some-rehlds.zip`.
+
 ## Goals of the project
 <ul>
 <li>Provide more stable (than official) version of Half-Life dedicated server with extended API for mods and plugins</li>
@@ -17,7 +26,8 @@ You can try playing on one of many servers that are using ReHLDS: [Game Tracker]
 ## How can use it?
 ReHLDS is fully compatible with the official pre-anniversary edition of HLDS (engine version <= 8684) downloaded by steamcmd. All you have to do is to download ReHLDS binaries and replace original swds.dll/engine_i486.so. For windows you can also copy a swds.pdb file with a debug information.
 
-<b>Warning!</b> ReHLDS is not compatible with an old 5xxx or below platforms downloaded by hldsupdatetool.
+> [!CAUTION]  
+> ReHLDS is not compatible with an old 5xxx or below platforms downloaded by hldsupdatetool.
 
 #### Downloading HLDS via steamcmd
 


### PR DESCRIPTION
- [X] Added signing of windows binaries, resolves  https://github.com/rehlds/.github/issues/30

- [X] Added resource metainfo to windows binaries, resolves https://github.com/rehlds/.github/issues/29

- [X] Added signing for linux binaries, resolves https://github.com/rehlds/.github/issues/28

-------------

> [!CAUTION]  
> This is `infrastructure` update! **NO** code and  **NO** bugfixes was implemented at `ReHLDS` at this PR.

-------------

Also, I know that we have .rc files that are used to create binaries.

The problem is that we have not yet fully decided how their future will develop from a development point of view. Also, now there are only 2 .rc files that are built into hlds.exe and hltv.exe. All other dlls are built naked, which excites antiviruses.

For now, I have chosen to use [rcedit](https://github.com/electron/rcedit), written by the Electron project, which can successfully read and edit resources in compiled files. Which is what I am actually doing.

For now, I suggest leaving it as is. To launch the mechanism. And optimize it in subsequent iterations of development, to move the progress forward a little.