### PR TITLE
Fix arbitrary network data sending exploit via malformed userinfo

### DIFF
--- a/rehlds/engine/info.cpp
+++ b/rehlds/engine/info.cpp
@@ -856,6 +856,12 @@ qboolean Info_IsValid(const char *s)
 		return false;
 	};
 
+	// invalid utf8 chars are deprecated
+	if (!Q_UnicodeValidate(s))
+	{
+		return FALSE;
+	}
+
 	while (*s == '\\')
 	{
 		const char* key = ++s;


### PR DESCRIPTION
This is a new exploit that was first mentioned in this issue - https://github.com/rehlds/ReHLDS/issues/1073

By using invalid utf8 chars in userinfo, an attacker can interrupt the reading of the string in `svc_updateuserinfo` for all connected clients, which will likely cause them to disconnect from the server due to incorrect reading of the rest of the packet. However, in addition to simply disconnecting clients, an attacker can append arbitrary network traffic to his userinfo, which connected clients can process. For example, in the PoC video below, an attacker compromises the `svc_stufftext` message, which executes some commands/cvars in the console of other clients:

https://www.youtube.com/watch?v=BIG7I859_aI

The thing is that when processing userinfo via the `setinfo` command, the server already has a check in the code for invalid utf8 chars, it is located in the `Info_SetValueForStarKey` func:

```c
if (!Q_UnicodeValidate(key) || !Q_UnicodeValidate(value))
{
	Con_Printf("Keys and values must be valid utf8 text\n");
	return FALSE;
}
```

But there is no such check for userinfo sent via `C2S_CONNECTION` message, so I suggest adding it to `Info_IsValid` func.

So this pr fixes this vulnerability.