### PR TITLE
Message Manager fix -- increase the number of parameters

### DIFF
--- a/rehlds/rehlds/rehlds_messagemngr_impl.cpp
+++ b/rehlds/rehlds/rehlds_messagemngr_impl.cpp
@@ -267,9 +267,9 @@ private:
 	};
 #pragma pack(pop)
 
-	static const size_t MAX_PARAMS = 16; // The maximum number of parameters allowed in the message
+	static const size_t MAX_PARAMS = 32; // The maximum number of parameters allowed in the message
 	Param_t m_params[MAX_PARAMS]{};      // The array of parameters in the message
-	size_t  m_paramCount : 4;            // The number of parameters in the message
+	size_t  m_paramCount : 5;            // The number of parameters in the message
 
 	void resetParam(size_t index);
 


### PR DESCRIPTION
## Purpose
Message Manager needs to support more than 16 parameteres to handle for example SVC_TEMPENTITY/TE_BEAMPOINTS.

## Approach
I've increased the number of parameters to 32.
