### PR TITLE
Fix VectorCompare func while compiling with clang with -flto=full flag enabled

### DIFF
--- a/rehlds/engine/mathlib_sse.cpp
+++ b/rehlds/engine/mathlib_sse.cpp
@@ -182,8 +182,12 @@ int BoxOnPlaneSide(vec_t *emins, vec_t *emaxs, mplane_t *p)
 
 qboolean VectorCompare(const vec_t *v1, const vec_t *v2)
 {
-	__m128 cmp = _mm_cmpneq_ps(_mm_loadu_ps(v1), _mm_loadu_ps(v2));
-	return !(_mm_movemask_ps(cmp) & (1|2|4));
+    // Load only valid datas
+    __m128 vec1 = _mm_setr_ps(v1[0], v1[1], v1[2], 0.0f);
+    __m128 vec2 = _mm_setr_ps(v2[0], v2[1], v2[2], 0.0f);
+    
+    __m128 cmp = _mm_cmpneq_ps(vec1, vec2);
+    return !(_mm_movemask_ps(cmp) & 0x7);
 }
 
 void AngleVectors(const vec_t *angles, vec_t *forward, vec_t *right, vec_t *up)

--- a/rehlds/engine/mathlib_sse.cpp
+++ b/rehlds/engine/mathlib_sse.cpp
@@ -182,12 +182,22 @@ int BoxOnPlaneSide(vec_t *emins, vec_t *emaxs, mplane_t *p)
 
 qboolean VectorCompare(const vec_t *v1, const vec_t *v2)
 {
-    // Load only valid datas
-    __m128 vec1 = _mm_setr_ps(v1[0], v1[1], v1[2], 0.0f);
-    __m128 vec2 = _mm_setr_ps(v2[0], v2[1], v2[2], 0.0f);
-    
-    __m128 cmp = _mm_cmpneq_ps(vec1, vec2);
-    return !(_mm_movemask_ps(cmp) & 0x7);
+	// Load the 3D vectors into 128-bit SIMD registers.
+	// The 4th component is set to 0.0f to safely fill the full register.
+	__m128 vec1 = _mm_setr_ps(v1[0], v1[1], v1[2], 0.0f);
+	__m128 vec2 = _mm_setr_ps(v2[0], v2[1], v2[2], 0.0f);
+
+	// Perform component-wise comparison for inequality (vec1[i] != vec2[i]).
+	__m128 cmp_result = _mm_cmpneq_ps(vec1, vec2);
+
+	// Extract the most significant bit of each float comparison result.
+	// This produces a 4-bit mask: bits [x y z w]
+	int mask = _mm_movemask_ps(cmp_result);
+
+	// Check if any of the first 3 components (x, y, z) are different.
+	// Bit 0: x, Bit 1: y, Bit 2: z
+	// If none of these bits are set, the vectors are equal.
+	return (mask & 0x7) == 0;
 }
 
 void AngleVectors(const vec_t *angles, vec_t *forward, vec_t *right, vec_t *up)


### PR DESCRIPTION
Fixed simd-function VectorCompare which had undefined behavior with -flto=full flag enabled while compiling via Clang
Also maybe this bug could be reproduced with others math fucntions. Need to investigate it further