### PR TITLE
fix(userinfo): prohibit ASCII control characters in keys and values

### DIFF
--- a/rehlds/engine/info.cpp
+++ b/rehlds/engine/info.cpp
@@ -589,7 +589,7 @@ qboolean Info_SetValueForStarKey(char *s, const char *key, const char *value, si
 
 	for (const char *p = key; *p; p++)
 	{
-		if (iscntrl(*p))
+		if (iscntrl((unsigned char)*p))
 		{
 			Con_Printf("Can't use keys with ASCII control characters\n");
 			return FALSE;
@@ -598,7 +598,7 @@ qboolean Info_SetValueForStarKey(char *s, const char *key, const char *value, si
 
 	for (const char *p = value; *p; p++)
 	{
-		if (iscntrl(*p))
+		if (iscntrl((unsigned char)*p))
 		{
 			Con_Printf("Can't use values with ASCII control characters\n");
 			return FALSE;
@@ -899,6 +899,9 @@ qboolean Info_IsValid(const char *s)
 			if (*s == '.' && *(s + 1) == '.')
 				return FALSE;
 
+			if (iscntrl((unsigned char)*s))
+				return FALSE;
+
 			s++;
 		}
 
@@ -920,6 +923,10 @@ qboolean Info_IsValid(const char *s)
 
 			// ".." deprecated
 			if (*s == '.' && *(s + 1) == '.')
+				return FALSE;
+
+			// control characters are prohibited
+			if (iscntrl((unsigned char)*s))
 				return FALSE;
 
 			s++;

--- a/rehlds/engine/info.cpp
+++ b/rehlds/engine/info.cpp
@@ -587,6 +587,24 @@ qboolean Info_SetValueForStarKey(char *s, const char *key, const char *value, si
 		return FALSE;
 	}
 
+	for (const char *p = key; *p; p++)
+	{
+		if (iscntrl(*p))
+		{
+			Con_Printf("Can't use keys with ASCII control characters\n");
+			return FALSE;
+		}
+	}
+
+	for (const char *p = value; *p; p++)
+	{
+		if (iscntrl(*p))
+		{
+			Con_Printf("Can't use values with ASCII control characters\n");
+			return FALSE;
+		}
+	}
+
 	int keyLen = Q_strlen(key);
 	int valueLen = Q_strlen(value);
 

--- a/rehlds/engine/info.cpp
+++ b/rehlds/engine/info.cpp
@@ -899,6 +899,7 @@ qboolean Info_IsValid(const char *s)
 			if (*s == '.' && *(s + 1) == '.')
 				return FALSE;
 
+			// control characters are prohibited
 			if (iscntrl((unsigned char)*s))
 				return FALSE;
 


### PR DESCRIPTION
## Description
This PR introduces validation in [`Info_SetValueForStarKey()`](https://github.com/rehlds/ReHLDS/blob/58da97789f3c924dc703bd590f10f5c4a3644543/rehlds/engine/info.cpp#L556-L648) to reject user info keys and values containing ASCII control characters (such as newlines), addressing crashes triggered by malformed user info strings.

## Problem
A malicious actor was detected sending a user info string with a model name containing `\r` (carriage return) or `\n` (line feed) characters, which triggers assertion failures in Windows clients. This led to clients aborting the game or repeatedly hitting the assertion, making ignoring an unacceptable choice.

## Changes
* Adds a check to reject ASCII control characters in both keys and values of user info.
