### PR TITLE
fix(hltv): defer intermission until server is running

### DIFF
--- a/rehlds/HLTV/Core/src/Server.h
+++ b/rehlds/HLTV/Core/src/Server.h
@@ -272,4 +272,8 @@ protected:
 	InfoString m_ServerInfo;
 	bool m_DelayReconnect;
 	unsigned int m_SeqNrMap[256];
+
+#ifdef HLTV_FIXES
+	bool m_PendingIntermission;
+#endif
 };


### PR DESCRIPTION
## Purpose
Fixes a crash caused by an invalid state transition when `svc_intermission` arrives before `SERVER_RUNNING`.
Closes #1115

## Approach
Defers intermission handling until after signon completes: if intermission arrives early, set a pending flag and apply `ParseIntermission()` right after the server enters `SERVER_RUNNING`.