### PR TITLE
fix: align DT_TIMEWINDOW with sv_rehlds_local_gametime

### DIFF
--- a/rehlds/engine/delta.h
+++ b/rehlds/engine/delta.h
@@ -172,3 +172,8 @@ void DELTA_PrintStats(const char *name, delta_t *p);
 void DELTA_DumpStats_f(void);
 void DELTA_Init(void);
 void DELTA_Shutdown(void);
+
+#ifdef REHLDS_FIXES
+void DELTA_SetTimeBaseOverride(double time, double offset);
+void DELTA_ClearTimeBaseOverride(void);
+#endif

--- a/rehlds/engine/sv_main.cpp
+++ b/rehlds/engine/sv_main.cpp
@@ -5003,7 +5003,13 @@ qboolean SV_SendClientDatagram(client_t *client)
 #ifdef REHLDS_FIXES
 	if (sv_rehlds_local_gametime.value != 0.0f)
 	{
-		MSG_WriteFloat(&msg, (float)g_GameClients[client - g_psvs.clients]->GetLocalGameTime());
+		CGameClient* gameClient = g_GameClients[client - g_psvs.clients];
+
+		double localGameTime = gameClient->GetLocalGameTime();
+		double localGameTimeBase = gameClient->GetLocalGameTimeBase();
+		DELTA_SetTimeBaseOverride(localGameTime, localGameTimeBase);
+
+		MSG_WriteFloat(&msg, (float)localGameTime);
 	}
 	else
 #endif
@@ -5039,6 +5045,10 @@ qboolean SV_SendClientDatagram(client_t *client)
 	}
 
 	Netchan_Transmit(&client->netchan, msg.cursize, buf);
+
+#ifdef REHLDS_FIXES
+	DELTA_ClearTimeBaseOverride();
+#endif
 
 	return TRUE;
 }


### PR DESCRIPTION
## Purpose
Fixes flickering of static studiomodels (map decorations, hostages, etc) when `sv_rehlds_local_gametime` is enabled.
Closes #1141 

## Approach
When `sv_rehlds_local_gametime` is enabled, the server sends `svc_time` in a per-client local timebase.
However, delta encoding for `DT_TIMEWINDOW_8` / `DT_TIMEWINDOW_BIG` previously always used `g_psv.time` as the reference, effectively mixing timebases.
This change adds the ability to override the time window encoding on a per-datagram basis, so that `DT_TIMEWINDOW_*` values ​​are encoded relative to the same time base as the `svc_time` sent to that client.

