### PR TITLE
Fix "executable stack" errors

### DIFF
--- a/rehlds/HLTV/Console/CMakeLists.txt
+++ b/rehlds/HLTV/Console/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
 project(hltv CXX)
 
+include(CheckCXXCompilerFlag)
+
 option(DEBUG "Build with debug information." OFF)
 
 set(CMAKE_CXX_STANDARD 14)
@@ -13,6 +15,18 @@ set(COMPILE_FLAGS "-m32 -fno-pic -fno-pie -U_FORTIFY_SOURCE -DFORTIFY_SOURCE=0")
 set(LINK_FLAGS "-m32 -no-pie -Wl,--no-export-dynamic")
 
 set(COMPILE_FLAGS "${COMPILE_FLAGS} -Wall -fno-exceptions -fno-strict-aliasing -fno-strict-overflow")
+
+check_cxx_compiler_flag("-Wa,--execstack" HAS_EXECSTACK_ASM)
+check_cxx_compiler_flag("-Wl,-z,execstack" HAS_EXECSTACK_LINK)
+
+# Glibc >=2.41 fixes
+if(HAS_EXECSTACK_ASM)
+	set(COMPILE_FLAGS "${COMPILE_FLAGS} -Wa,--execstack")
+endif()
+
+if(HAS_EXECSTACK_LINK)
+	set(LINK_FLAGS "${LINK_FLAGS} -Wl,-z,execstack")
+endif()
 
 if (DEBUG)
 	set(COMPILE_FLAGS "${COMPILE_FLAGS} -g3 -O3 -ggdb")

--- a/rehlds/dedicated/CMakeLists.txt
+++ b/rehlds/dedicated/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.1)
 project(hlds CXX)
 
+include(CheckCXXCompilerFlag)
+
 option(DEBUG "Build with debug information." OFF)
 
 set(CMAKE_CXX_STANDARD 14)
@@ -13,6 +15,18 @@ set(COMPILE_FLAGS "-m32 -fno-pic -fno-pie -U_FORTIFY_SOURCE -DFORTIFY_SOURCE=0")
 set(LINK_FLAGS "-m32 -no-pie -Wl,--no-export-dynamic")
 
 set(COMPILE_FLAGS "${COMPILE_FLAGS} -Wall -fno-exceptions -fno-strict-aliasing -fno-strict-overflow")
+
+check_cxx_compiler_flag("-Wa,--execstack" HAS_EXECSTACK_ASM)
+check_cxx_compiler_flag("-Wl,-z,execstack" HAS_EXECSTACK_LINK)
+
+# Glibc >=2.41 fixes
+if(HAS_EXECSTACK_ASM)
+	set(COMPILE_FLAGS "${COMPILE_FLAGS} -Wa,--execstack")
+endif()
+
+if(HAS_EXECSTACK_LINK)
+	set(LINK_FLAGS "${LINK_FLAGS} -Wl,-z,execstack")
+endif()
 
 if (DEBUG)
 	set(COMPILE_FLAGS "${COMPILE_FLAGS} -g3 -O3 -ggdb")


### PR DESCRIPTION
## Purpose
Fixes #1079 

## Approach
Adds the compiler and linker flags `-Wa,--execstack` and `-Wl,-z,execstack` respectively, as proposed by @anzz1 in the discussion on that issue.

I have tested these fixes and no longer crash due to the "executable stack" error on both Debian 13 and Fedora 42 (both with glibc 2.41).