### PR TITLE
Implement SV_TestEntityPosition hook to ReAPI

### DIFF
--- a/rehlds/engine/world.cpp
+++ b/rehlds/engine/world.cpp
@@ -710,7 +710,15 @@ int SV_PointContents(const vec_t *p)
 }
 
 // Returns true if the entity is in solid currently
-edict_t *SV_TestEntityPosition(edict_t *ent)
+edict_t *EXT_FUNC SV_TestEntityPosition(edict_t *ent)
+{
+	return g_RehldsHookchains.m_SV_TestEntityPosition.callChain(
+		SV_TestEntityPosition_internal,
+		ent
+	);
+}
+
+edict_t *EXT_FUNC SV_TestEntityPosition_internal(edict_t *ent)
 {
 	qboolean monsterClip = (ent->v.flags & FL_MONSTERCLIP) ? TRUE : FALSE;
 	trace_t trace = SV_Move(ent->v.origin, ent->v.mins, ent->v.maxs, ent->v.origin, MOVE_NORMAL, ent, monsterClip);

--- a/rehlds/engine/world.h
+++ b/rehlds/engine/world.h
@@ -102,6 +102,7 @@ int SV_HullPointContents(hull_t *hull, int num, const vec_t *p);
 int SV_LinkContents(areanode_t *node, const vec_t *pos);
 int SV_PointContents(const vec_t *p);
 edict_t *SV_TestEntityPosition(edict_t *ent);
+edict_t *SV_TestEntityPosition_internal(edict_t *ent);
 qboolean SV_RecursiveHullCheck(hull_t *hull, int num, float p1f, float p2f, const vec_t *p1, const vec_t *p2, trace_t *trace);
 void SV_SingleClipMoveToEntity(edict_t *ent, const vec_t *start, const vec_t *mins, const vec_t *maxs, const vec_t *end, trace_t *trace);
 trace_t SV_ClipMoveToEntity(edict_t *ent, const vec_t *start, const vec_t *mins, const vec_t *maxs, const vec_t *end);

--- a/rehlds/public/rehlds/rehlds_api.h
+++ b/rehlds/public/rehlds/rehlds_api.h
@@ -264,6 +264,10 @@ typedef IHookChainRegistry<bool, edict_t*, edict_t*> IRehldsHookRegistry_SV_Allo
 typedef IVoidHookChain<sizebuf_t *> IRehldsHook_SV_SendResources;
 typedef IVoidHookChainRegistry<sizebuf_t *> IRehldsHookRegistry_SV_SendResources;
 
+//SV_TestEntityPosition hook
+typedef IHookChain<edict_t*, edict_t*> IRehldsHook_SV_TestEntityPosition;
+typedef IHookChainRegistry<edict_t*, edict_t*> IRehldsHookRegistry_SV_TestEntityPosition;
+
 class IRehldsHookchains {
 public:
 	virtual ~IRehldsHookchains() { }
@@ -324,6 +328,7 @@ public:
 	virtual IRehldsHookRegistry_SV_ClientPrintf* SV_ClientPrintf() = 0;
 	virtual IRehldsHookRegistry_SV_AllowPhysent* SV_AllowPhysent() = 0;
 	virtual IRehldsHookRegistry_SV_SendResources* SV_SendResources() = 0;
+	virtual IRehldsHookRegistry_SV_TestEntityPosition* SV_TestEntityPosition() = 0;
 };
 
 struct RehldsFuncs_t {

--- a/rehlds/rehlds/rehlds_api_impl.cpp
+++ b/rehlds/rehlds/rehlds_api_impl.cpp
@@ -925,6 +925,10 @@ IRehldsHookRegistry_SV_SendResources* CRehldsHookchains::SV_SendResources() {
 	return &m_SV_SendResources;
 }
 
+IRehldsHookRegistry_SV_TestEntityPosition* CRehldsHookchains::SV_TestEntityPosition() {
+	return &m_SV_TestEntityPosition;
+}
+
 int EXT_FUNC CRehldsApi::GetMajorVersion()
 {
 	return REHLDS_API_VERSION_MAJOR;

--- a/rehlds/rehlds/rehlds_api_impl.h
+++ b/rehlds/rehlds/rehlds_api_impl.h
@@ -254,6 +254,10 @@ typedef IVoidHookChainRegistryImpl<const char*> CRehldsHookRegistry_SV_ClientPri
 typedef IHookChainImpl<bool, edict_t*, edict_t*> CRehldsHook_SV_AllowPhysent;
 typedef IHookChainRegistryImpl<bool, edict_t*, edict_t*> CRehldsHookRegistry_SV_AllowPhysent;
 
+// SV_TestEntityPosition hook
+typedef IHookChainImpl<edict_t*, edict_t*> CRehldsHook_SV_TestEntityPosition;
+typedef IHookChainRegistryImpl<edict_t*, edict_t*> CRehldsHookRegistry_SV_TestEntityPosition;
+
 //SV_SendResources hook
 typedef IVoidHookChainImpl<sizebuf_t *> CRehldsHook_SV_SendResources;
 typedef IVoidHookChainRegistryImpl<sizebuf_t *> CRehldsHookRegistry_SV_SendResources;
@@ -316,6 +320,7 @@ public:
 	CRehldsHookRegistry_SV_ClientPrintf m_SV_ClientPrintf;
 	CRehldsHookRegistry_SV_AllowPhysent m_SV_AllowPhysent;
 	CRehldsHookRegistry_SV_SendResources m_SV_SendResources;
+	CRehldsHookRegistry_SV_TestEntityPosition m_SV_TestEntityPosition;
 
 public:
 	EXT_FUNC virtual IRehldsHookRegistry_Steam_NotifyClientConnect* Steam_NotifyClientConnect();
@@ -374,6 +379,7 @@ public:
 	EXT_FUNC virtual IRehldsHookRegistry_SV_ClientPrintf* SV_ClientPrintf();
 	EXT_FUNC virtual IRehldsHookRegistry_SV_AllowPhysent* SV_AllowPhysent();
 	EXT_FUNC virtual IRehldsHookRegistry_SV_SendResources* SV_SendResources();
+	EXT_FUNC virtual IRehldsHookRegistry_SV_TestEntityPosition* SV_TestEntityPosition();
 };
 
 extern CRehldsHookchains g_RehldsHookchains;


### PR DESCRIPTION
## Purpose
This adds support for SV_TestEntityPosition in ReAPI.

## Approach
SV_TestEntityPosition is called most of the time whenever a entity checks if it's blocking a BSP entity, allowing plugin makers to fix bugs in Semiclip solutions. 

## Open Questions and Pre-Merge TODOs
None, this change was implemented proactively.

## Learning
I saw how other hooks were implemented and tried to follow as closely as possible. 