### PR TITLE
fix: add NULL check for host_client->edict in SV_RunCmd

### DIFF
--- a/rehlds/engine/sv_user.cpp
+++ b/rehlds/engine/sv_user.cpp
@@ -1050,7 +1050,7 @@ void SV_RunCmd(usercmd_t* ucmd, int random_seed, qboolean fNetCmd, qboolean fCho
 	sv_player->v.vuser4[2] = pmove->vuser4[2];
 
 	SetMinMaxSize(sv_player, player_mins[pmove->usehull], player_maxs[pmove->usehull], 0);
-	if (host_client->edict->v.solid)
+	if (host_client->edict && host_client->edict->v.solid)
 	{
 		SV_LinkEdict(sv_player, TRUE);
 		vec3_t vel;


### PR DESCRIPTION
Prevents SIGSEGV when host_client->edict is NULL while dereferencing v.solid at sv_user.cpp:1053. The edict pointer can become NULL during entity callbacks (e.g. pfnCmdStart, pfnPlayerPreThink, pfnPM_Move) when a plugin triggers SV_DropClient within the same frame.

## Purpose

HLDS crashes with SIGSEGV (signal 11) at `engine_i486.so` offset `0x2304b` inside
`SV_RunCmd`. The instruction `mov 0x18c(%ecx),%esi` dereferences `host_client->edict->v.solid`
where `host_client->edict` is NULL. Fault address: `0x18c`.

Trigger: an AMXX plugin (ATAC team-attack counter + AMXBans) calls `SV_DropClient` via
the command buffer during an entity callback that fires inside `SV_RunCmd` before line 1053,
notably `pfnCmdStart`, `pfnPlayerPreThink`, `pfnPlayerThink`, or `pfnPM_Move`. Once
`host_client->edict` is nulled by `SV_DropClient_internal` in `host.cpp:518`, any
subsequent dereference in the same frame crashes.

Reproducible across multiple maps; confirmed in 5+ core dumps and minidumps from
a CS 1.6 server running reHLDS 3.15.0.896 + AMXX 1.10.0.5476.

## Approach

Add a single NULL guard: `if (host_client->edict && host_client->edict->v.solid)`.
When the edict pointer is NULL the entire `SV_LinkEdict` / touch-handling block is
skipped, which is safe because there is no entity to link. The function then proceeds
to `pfnPlayerPostThink` and `pfnCmdEnd` (also guarded in the follow-up commit 2d85a11).

The fix is minimal — one addition — and does not alter any logic paths for valid entities.

#### Open Questions and Pre-Merge TODOs
- [x] Verified binary disassembly matches source: `0x18c` = `edict->v.solid` (edict offset `0x80` + entvars `solid` at `0x10c`)
- [x] Confirmed 5 independent crash dumps share the same EIP
- [x] Root cause traced to `SV_DropClient` nulling `cl->edict` mid-frame via plugin callbacks
- [X] Backport to upstream reHLDS: the same bug exists in ReHLDS `master` at `sv_user.cpp:1053`

## Learning

The failed `pClient->edict` pointer at offset `0x4a84` in `client_t` was identified by
tracing the crash EIP to the disassembly, cross-referencing with `progdefs.h` (`entvars_t`
layout) and `server.h` (`client_s` layout). The engine misses the NULL check because
vanilla HLDS never exposes `host_client->edict` to callbacks that can drop the client
— this became visible only with AMXX/metamod hooking the entity interface at every
movement callback stage.

`addr2line` confirmed: `SV_RunCmd(usercmd_s*, int, int, int)`.
`eu-readelf -n` on the core dump provided signal, register, and memory-map data.
`objdump -d` provided the exact instruction-level trace.