### PR TITLE
engine: add sv_reconnect_timeout to drop clients that never reconnect after a level change

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ This means that plugins that do binary code analysis (Orpheu for example) probab
 <li>sv_rehlds_movecmdtime_min_scale // Defines the min client's base game speed ratio. Clients slowing the game down below this multiplier will receive warnings. Default: 0.5
 <li>sv_rehlds_movecmdtime_max_warnings // Maximum allowed speedhack/slowmo warnings before the punishment is applied. -1 - disable detection. Default: -1
 <li>sv_rehlds_movecmdtime_punish // Time in minutes for which the player will be banned for speedhacking/slowing (-1 - Kick, 0 - Permanent, use a negative number for a kick). Default: -1
+<li>sv_reconnect_timeout // Hard deadline in seconds for a client to re-initiate its connection after a level change, independent of netchan activity. Closes a phantom-slot exploit where a cheat blocks the "reconnect" command and keeps the netchan warm so sv_timeout never fires. 0 - disabled. Default: 30
 </ul>
 </details>
 

--- a/rehlds/engine/sv_main.cpp
+++ b/rehlds/engine/sv_main.cpp
@@ -212,7 +212,6 @@ cvar_t sv_timeout = { "sv_timeout", "60", 0, 0.0f, NULL };
 // on changelevel and keeps the netchan warm, so the normal sv_timeout (which keys off
 // netchan.last_received) never fires and the half-connected slot survives forever. 0 = disabled.
 cvar_t sv_reconnect_timeout = { "sv_reconnect_timeout", "30", 0, 0.0f, NULL };
-static double g_ReconnectDeadline[MAX_CLIENTS];
 #endif // REHLDS_FIXES
 cvar_t sv_failuretime = { "sv_failuretime", "0.5", 0, 0.0f, NULL };
 cvar_t sv_cheats = { "sv_cheats", "0", FCVAR_SERVER, 0.0f, NULL };
@@ -2542,7 +2541,7 @@ void EXT_FUNC SV_ConnectClient_internal(void)
 	// Client (re)established its connection, so it obeyed the level-change "reconnect" command.
 	// Disarm the deadline armed by SV_InactivateClients. This happens before any resource
 	// download/spawn, so downloading players are never affected.
-	g_ReconnectDeadline[host_client - g_psvs.clients] = 0.0;
+	g_GameClients[host_client - g_psvs.clients]->SetReconnectDeadline(0.0);
 #endif // REHLDS_FIXES
 
 	bIsSecure = Steam_GSBSecure();
@@ -4011,17 +4010,18 @@ void SV_CheckTimeouts(void)
 		// time (see SV_InactivateClients), NOT from netchan.last_received, so a cheat that keeps
 		// the netchan warm to block the "reconnect" command (oxware svc_stufftext filter ->
 		// phantom slot) cannot dodge it the way it dodges the normal sv_timeout.
-		if (g_ReconnectDeadline[i] != 0.0)
+		double reconnectDeadline = g_GameClients[i]->GetReconnectDeadline();
+		if (reconnectDeadline != 0.0)
 		{
 			if (cl->fully_connected)
 			{
 				// Reconnect finished normally; stand down.
-				g_ReconnectDeadline[i] = 0.0;
+				g_GameClients[i]->SetReconnectDeadline(0.0);
 			}
-			else if (sv_reconnect_timeout.value > 0.0 && (realtime - g_ReconnectDeadline[i]) > sv_reconnect_timeout.value)
+			else if (sv_reconnect_timeout.value > 0.0 && (realtime - reconnectDeadline) > sv_reconnect_timeout.value)
 			{
 				Con_DPrintf("Dropping %s: failed to reconnect within %.0fs after level change\n", cl->name, sv_reconnect_timeout.value);
-				g_ReconnectDeadline[i] = 0.0;
+				g_GameClients[i]->SetReconnectDeadline(0.0);
 				SV_DropClient(cl, FALSE, "Failed to reconnect after level change");
 				continue;
 			}
@@ -7761,7 +7761,7 @@ void SV_InactivateClients(void)
 			// (SV_ConnectClient clears it) within sv_reconnect_timeout, or SV_CheckTimeouts
 			// force-drops it regardless of netchan activity. Closes the oxware changelevel
 			// phantom-slot exploit, where the cheat blocks "reconnect" and keeps the netchan warm.
-			g_ReconnectDeadline[i] = realtime;
+			g_GameClients[i]->SetReconnectDeadline(realtime);
 #endif // REHLDS_FIXES
 
 			SZ_Clear(&cl->netchan.message);

--- a/rehlds/engine/sv_main.cpp
+++ b/rehlds/engine/sv_main.cpp
@@ -203,6 +203,17 @@ cvar_t sv_newunit = { "sv_newunit", "0", 0, 0.0f, NULL };
 
 cvar_t sv_clienttrace = { "sv_clienttrace", "1", FCVAR_SERVER, 0.0f, NULL };
 cvar_t sv_timeout = { "sv_timeout", "60", 0, 0.0f, NULL };
+#ifdef REHLDS_FIXES
+// Hard deadline (in seconds) for a client to complete a reconnect after a level change.
+// A client that SV_InactivateClients put into the reconnect-pending state but that never
+// re-initiates its connection within this window is force-dropped by SV_CheckTimeouts,
+// independent of the netchan inactivity timeout. This defeats the oxware "svc_stufftext
+// reconnect filter" phantom-slot exploit: the cheat blocks the engine's "reconnect" command
+// on changelevel and keeps the netchan warm, so the normal sv_timeout (which keys off
+// netchan.last_received) never fires and the half-connected slot survives forever. 0 = disabled.
+cvar_t sv_reconnect_timeout = { "sv_reconnect_timeout", "30", 0, 0.0f, NULL };
+static double g_ReconnectDeadline[MAX_CLIENTS];
+#endif // REHLDS_FIXES
 cvar_t sv_failuretime = { "sv_failuretime", "0.5", 0, 0.0f, NULL };
 cvar_t sv_cheats = { "sv_cheats", "0", FCVAR_SERVER, 0.0f, NULL };
 cvar_t sv_password = { "sv_password", "", FCVAR_SERVER | FCVAR_PROTECTED, 0.0f, NULL };
@@ -2528,6 +2539,10 @@ void EXT_FUNC SV_ConnectClient_internal(void)
 #ifdef REHLDS_FIXES
 	host_client->m_bSentNewResponse = FALSE;
 	g_GameClients[host_client - g_psvs.clients]->SetSpawnedOnce(false);
+	// Client (re)established its connection, so it obeyed the level-change "reconnect" command.
+	// Disarm the deadline armed by SV_InactivateClients. This happens before any resource
+	// download/spawn, so downloading players are never affected.
+	g_ReconnectDeadline[host_client - g_psvs.clients] = 0.0;
 #endif // REHLDS_FIXES
 
 	bIsSecure = Steam_GSBSecure();
@@ -3990,6 +4005,28 @@ void SV_CheckTimeouts(void)
 	{
 		if (cl->fakeclient)
 			continue;
+#ifdef REHLDS_FIXES
+		// Force-drop a client that was inactivated on level change but never re-initiated its
+		// connection within sv_reconnect_timeout. This deadline is measured from the inactivation
+		// time (see SV_InactivateClients), NOT from netchan.last_received, so a cheat that keeps
+		// the netchan warm to block the "reconnect" command (oxware svc_stufftext filter ->
+		// phantom slot) cannot dodge it the way it dodges the normal sv_timeout.
+		if (g_ReconnectDeadline[i] != 0.0)
+		{
+			if (cl->fully_connected)
+			{
+				// Reconnect finished normally; stand down.
+				g_ReconnectDeadline[i] = 0.0;
+			}
+			else if (sv_reconnect_timeout.value > 0.0 && (realtime - g_ReconnectDeadline[i]) > sv_reconnect_timeout.value)
+			{
+				Con_DPrintf("Dropping %s: failed to reconnect within %.0fs after level change\n", cl->name, sv_reconnect_timeout.value);
+				g_ReconnectDeadline[i] = 0.0;
+				SV_DropClient(cl, FALSE, "Failed to reconnect after level change");
+				continue;
+			}
+		}
+#endif // REHLDS_FIXES
 		if (!cl->connected && !cl->active && !cl->spawned)
 			continue;
 		if (cl->netchan.last_received < droptime)
@@ -7719,6 +7756,14 @@ void SV_InactivateClients(void)
 			cl->hasusrmsgs = FALSE;
 			cl->m_bSentNewResponse = FALSE;
 
+#ifdef REHLDS_FIXES
+			// Arm the reconnect deadline: this slot must re-initiate its connection
+			// (SV_ConnectClient clears it) within sv_reconnect_timeout, or SV_CheckTimeouts
+			// force-drops it regardless of netchan activity. Closes the oxware changelevel
+			// phantom-slot exploit, where the cheat blocks "reconnect" and keeps the netchan warm.
+			g_ReconnectDeadline[i] = realtime;
+#endif // REHLDS_FIXES
+
 			SZ_Clear(&cl->netchan.message);
 			SZ_Clear(&cl->datagram);
 
@@ -8314,6 +8359,9 @@ void SV_Init(void)
 	Cvar_RegisterVariable(&sv_skyvec_y);
 	Cvar_RegisterVariable(&sv_skyvec_z);
 	Cvar_RegisterVariable(&sv_timeout);
+#ifdef REHLDS_FIXES
+	Cvar_RegisterVariable(&sv_reconnect_timeout);
+#endif // REHLDS_FIXES
 	Cvar_RegisterVariable(&sv_clienttrace);
 	Cvar_RegisterVariable(&sv_zmax);
 	Cvar_RegisterVariable(&sv_wateramp);

--- a/rehlds/rehlds/rehlds_interfaces_impl.cpp
+++ b/rehlds/rehlds/rehlds_interfaces_impl.cpp
@@ -34,6 +34,7 @@ CGameClient::CGameClient(int id, client_t* cl)
 	: m_NetChan(&cl->netchan)
 #ifdef REHLDS_FIXES
 	, m_localGameTimeBase(0)
+	, m_reconnectDeadline(0)
 #endif
 {
 	m_Id = id;

--- a/rehlds/rehlds/rehlds_interfaces_impl.h
+++ b/rehlds/rehlds/rehlds_interfaces_impl.h
@@ -84,6 +84,11 @@ private:
 
 #ifdef REHLDS_FIXES
 	double m_localGameTimeBase;
+
+	// Hard deadline (realtime) by which a client inactivated on a level change must re-initiate
+	// its connection, or SV_CheckTimeouts force-drops it. Armed in SV_InactivateClients, cleared
+	// in SV_ConnectClient_internal. 0 = not armed. See sv_reconnect_timeout.
+	double m_reconnectDeadline;
 #endif
 public:
 	CGameClient(int id, client_t* cl);
@@ -271,6 +276,9 @@ public:
 	void SetupLocalGameTime() { m_localGameTimeBase = g_psv.time; }
 	double GetLocalGameTime() const { return g_psv.time - m_localGameTimeBase; }
 	double GetLocalGameTimeBase() const { return m_localGameTimeBase; }
+
+	double GetReconnectDeadline() const { return m_reconnectDeadline; }
+	void SetReconnectDeadline(double time) { m_reconnectDeadline = time; }
 #endif
 };
 


### PR DESCRIPTION
Adds a server-side deadline for clients to re-initiate their connection after a level change. A client that the engine put into the reconnect-pending state on `changelevel` but that never sends a new connection request within `sv_reconnect_timeout` seconds is now force-dropped by `SV_CheckTimeouts`, independent of the netchan inactivity timeout.

This closes a phantom-slot vector that survives `changelevel` and is currently abusable as a lag/CPU (L7) amplifier. Related reports: #1098, #1054.

On `changelevel`, `SV_InactivateClients()` does **not** drop real clients — it flips them to `connected = TRUE, spawned = FALSE, fully_connected = FALSE` and the engine sends each one a `reconnect` command (`svc_stufftext`, see `SV_BuildReconnect`). The client is then expected to reconnect **on its own**.

If a client silently drops that `reconnect` command (a publicly available cheat does exactly this with an `svc_stufftext` filter) while keeping its netchan warm, the slot stays half-alive forever:

- `SV_CheckTimeouts()` is the only thing that could remove it, but it keys off `cl->netchan.last_received < realtime - sv_timeout`. A warm netchan keeps `last_received` fresh, so the inactivity timeout **never fires**.
- There is no separate "you must finish reconnecting within N seconds" deadline.

Result: a `connected && !spawned && !fully_connected` client persists across the map change. It occupies a slot, is counted as active, shows no ping on the scoreboard (`SV_CalcPing` has no frame samples for it), and — because it bypasses the spawned-only rate/flood paths — can be used to load the server / spike everyone's ping. Restarting the map clears it, which is why these reports look like an "exploit, not a DDoS".

`SV_InactivateClients()` arms no completion deadline, and `SV_CheckTimeouts()` measures liveness from `netchan.last_received`, which a client fully controls by sending any packet.

The fix tracks, per slot, the moment a client was inactivated by a level change, and enforces a hard deadline that is **independent of `last_received`**:

- `SV_InactivateClients()` — record `realtime` for each real client it inactivates (arm).
- `SV_ConnectClient_internal()` — clear it the moment the client re-establishes its connection (proof it obeyed `reconnect`). Cleared **before** any resource download/spawn, so downloading players are never affected.
- `SV_CheckTimeouts()` — if a slot is still armed and not `fully_connected` after `sv_reconnect_timeout` seconds, force-drop it.

The deadline only covers the narrow window "told to reconnect → has not yet sent a connection request". For any real client this is sub-second; only a client that never reconnects at all trips it.

State is kept in a file-local `static double[MAX_CLIENTS]` rather than a `client_t` field, to avoid changing the struct layout (`structSizeCheck`). Guarded by `REHLDS_FIXES`.

New cvar:

| Cvar | Default | Description |
|------|---------|-------------|
| `sv_reconnect_timeout` | `30` | Seconds a client may take to reconnect after a level change before being force-dropped. `0` disables the check. |

It only needs to cover the network handshake (not downloads), so the default is generous.

Reproduction:

1. Connect a client that filters the server `reconnect` stufftext command and keeps its netchan alive.
2. Trigger a `changelevel`.
3. Before: the client stays as a half-connected, ping-less phantom slot indefinitely; map restart is the only way to clear it.
4. After (with `sv_reconnect_timeout > 0`): the slot is dropped `sv_reconnect_timeout` seconds after the level change with reason `Failed to reconnect after level change`.

Testing:

- Built `Release|Win32` (MSVC), no struct-size assertion failures.
- Legit clients (including ones that download the new map via fastdl after reconnecting) are unaffected: their deadline is cleared in `SV_ConnectClient_internal` before downloads begin.
- Phantom slot is dropped at the deadline; server load / ping return to normal.

Notes:

- All changes are additive and gated behind `REHLDS_FIXES`.
- No `client_t` layout change.
- Backwards compatible: `sv_reconnect_timeout 0` restores the previous behavior exactly.
