### PR TITLE
engine: fix lag compensation hitbox animation sync

### DIFF
--- a/rehlds/engine/sv_user.h
+++ b/rehlds/engine/sv_user.h
@@ -47,6 +47,26 @@ typedef struct sv_adjusted_positions_s
 	int deadflag;
 	vec3_t temp_org;
 	int temp_org_setflag;
+	// Lag compensation: backup/restore animation state used for studio hitboxes
+	int anim_saved;
+	int oldsequence;
+	float oldframe;
+	vec3_t oldangles;
+	byte oldblending[4];
+	byte oldcontroller[4];
+	int oldusehull;
+	vec3_t oldmins;
+	vec3_t oldmaxs;
+	int oldflags;
+	int newsequence;
+	float newframe;
+	vec3_t newangles;
+	byte newblending[4];
+	byte newcontroller[4];
+	int newusehull;
+	vec3_t newmins;
+	vec3_t newmaxs;
+	int newflags;
 } sv_adjusted_positions_t;
 
 typedef struct clc_func_s


### PR DESCRIPTION
engine: fix lag compensation hitbox animation sync

## Summary

- PR title: `engine: fix lag compensation hitbox animation sync`

---

Copy everything below into the GitHub PR description:

---

### What

Fix incorrect server-side hitboxes during lag compensation rewind and for non-movement studio sequences.

### Why (Root cause)

`SV_SetupMove` rewinds player origin for unlag traces but leaves animation state (sequence, frame, blending, controller, duck hull) at the current tick. Hitbox calculation in `SV_HullForStudioModel` therefore uses stale/wrong data.

Additionally, the engine always called `R_StudioPlayerBlend()` even for sequences where `numblends != 9` (reload, duck, plant C4), ignoring networked blending/controller.

### How it works

- Extend `sv_adjusted_positions_t` with animation backup fields
- `SV_LagCompSaveAnimState` / `SV_LagCompApplyAnimState` / `SV_LagCompRestoreAnimState` in lag comp path
- Call apply in `SV_SetupMove`, restore in `SV_RestoreMove`
- `SV_HullForStudioModel`: for `numblends != 9`, use entity blending/controller from network state
- `R_FlushStudioCache()` after animation changes

All changes under `#ifdef REHLDS_FIXES`.

Related community fix: https://github.com/Garey27/hitbox_fixer (plugin approach).

### Companion PR

**Requires ReGameDLL_CS PR:** rehlds/ReGameDLL_CS#XXXX

Both must be built and deployed together.

### Tested

- Release build, Linux i486 (Debian 11 / glibc 2.31) and Windows MSVC
- Live CS 1.6 dedicated server, `sv_unlag 1`
- Verified: spawn head hitbox, duck/reload traces, high-ping lag compensation shots

Fixes #XXXX

Reference implementation: https://github.com/cspburgija/cs16-server-hitbox-fix

Fixes https://github.com/rehlds/ReHLDS/issues/1190
Companion PR: (https://github.com/rehlds/ReGameDLL_CS/issues/1171)