### PR TITLE
HLTV: remove hardcoded -flto from non-PIC i386 shared libraries

### DIFF
--- a/rehlds/HLTV/Core/CMakeLists.txt
+++ b/rehlds/HLTV/Core/CMakeLists.txt
@@ -32,7 +32,7 @@ if ("$ENV{CXX}" MATCHES "icpc")
 else()
 	# Produce code optimized for the most common IA32/AMD64/EM64T processors.
 	# As new processors are deployed in the marketplace, the behavior of this option will change.
-	set(COMPILE_FLAGS "${COMPILE_FLAGS} -mtune=generic -msse3 -flto\
+	set(COMPILE_FLAGS "${COMPILE_FLAGS} -mtune=generic -msse3\
 		-fpermissive -fno-sized-deallocation\
 		-Wno-unused-result -Wno-unknown-pragmas -Wno-unused-variable\
 		-Wno-sign-compare -Wno-write-strings -Wno-strict-aliasing")

--- a/rehlds/HLTV/DemoPlayer/CMakeLists.txt
+++ b/rehlds/HLTV/DemoPlayer/CMakeLists.txt
@@ -33,7 +33,7 @@ else()
 	# Produce code optimized for the most common IA32/AMD64/EM64T processors.
 	# As new processors are deployed in the marketplace, the behavior of this option will change.
 	set(COMPILE_FLAGS "${COMPILE_FLAGS} \
-		-mtune=generic -msse3 -flto\
+		-mtune=generic -msse3\
 		-fpermissive -fno-sized-deallocation\
 		-Wno-unused-result -Wno-unknown-pragmas\
 		-Wno-sign-compare -Wno-write-strings -Wno-strict-aliasing")

--- a/rehlds/HLTV/Director/CMakeLists.txt
+++ b/rehlds/HLTV/Director/CMakeLists.txt
@@ -33,7 +33,7 @@ else()
 	# Produce code optimized for the most common IA32/AMD64/EM64T processors.
 	# As new processors are deployed in the marketplace, the behavior of this option will change.
 	set(COMPILE_FLAGS "${COMPILE_FLAGS} \
-		-mtune=generic -msse3 -flto\
+		-mtune=generic -msse3\
 		-fpermissive -fno-sized-deallocation\
 		-Wno-unused-result -Wno-unknown-pragmas\
 		-Wno-write-strings -Wno-strict-aliasing")

--- a/rehlds/HLTV/Proxy/CMakeLists.txt
+++ b/rehlds/HLTV/Proxy/CMakeLists.txt
@@ -33,7 +33,7 @@ else()
 	# Produce code optimized for the most common IA32/AMD64/EM64T processors.
 	# As new processors are deployed in the marketplace, the behavior of this option will change.
 	set(COMPILE_FLAGS "${COMPILE_FLAGS} \
-		-mtune=generic -msse3 -flto\
+		-mtune=generic -msse3\
 		-fpermissive -fno-sized-deallocation\
 		-Wno-unused-result -Wno-unknown-pragmas -Wno-unused-variable\
 		-Wno-write-strings -Wno-strict-aliasing")


### PR DESCRIPTION
## Problem

The four HLTV components (Core, Proxy, Director, DemoPlayer) hardcode `-flto` in `COMPILE_FLAGS`. When built as i386 shared libraries without `-fPIC` (`POSITION_INDEPENDENT_CODE OFF`), the LTO pass re-generates code at link time that places relocations in read-only `.text` sections. Modern ld (≥ 2.36) treats this as a hard error:

```
ld: warning: relocation against '...' in read-only section '.text'
ld: read-only segment has dynamic relocations
collect2: error: ld returned 1 exit status
```

## Fix

Remove `-flto` from `COMPILE_FLAGS` in the four affected `CMakeLists.txt` files. LTO is best left to the build system or packager (e.g. via `CMAKE_INTERPROCEDURAL_OPTIMIZATION`) rather than hardcoded in source.

## Files changed

- `rehlds/HLTV/Core/CMakeLists.txt`
- `rehlds/HLTV/Proxy/CMakeLists.txt`
- `rehlds/HLTV/Director/CMakeLists.txt`
- `rehlds/HLTV/DemoPlayer/CMakeLists.txt`