### PR TITLE
cmake: allow text relocations for non-PIC i386 shared libraries

### DIFF
--- a/rehlds/CMakeLists.txt
+++ b/rehlds/CMakeLists.txt
@@ -293,6 +293,8 @@ set(LINK_FLAGS "${LINK_FLAGS} \
 	-Wl,-rpath,'$ORIGIN/.' \
 	-L${PROJECT_SOURCE_DIR}/lib/linux32")
 
+set(LINK_FLAGS "${LINK_FLAGS} -Wl,-z,notext")
+
 set_target_properties(engine PROPERTIES
 	OUTPUT_NAME engine_i486
 	PREFIX ""

--- a/rehlds/HLTV/Core/CMakeLists.txt
+++ b/rehlds/HLTV/Core/CMakeLists.txt
@@ -136,6 +136,8 @@ if (NOT TARGET bzip2)
 	add_subdirectory(../../../dep/bzip2 lib)
 endif()
 
+set(LINK_FLAGS "${LINK_FLAGS} -Wl,-z,notext")
+
 set_target_properties(core PROPERTIES
 	OUTPUT_NAME core
 	PREFIX ""

--- a/rehlds/HLTV/DemoPlayer/CMakeLists.txt
+++ b/rehlds/HLTV/DemoPlayer/CMakeLists.txt
@@ -105,6 +105,8 @@ target_link_libraries(demoplayer PRIVATE
 	m
 )
 
+set(LINK_FLAGS "${LINK_FLAGS} -Wl,-z,notext")
+
 set_target_properties(demoplayer PROPERTIES
 	OUTPUT_NAME demoplayer
 	PREFIX ""

--- a/rehlds/HLTV/Director/CMakeLists.txt
+++ b/rehlds/HLTV/Director/CMakeLists.txt
@@ -111,6 +111,8 @@ set(LINK_FLAGS "${LINK_FLAGS} \
 	-Wl,-rpath,'$ORIGIN/.' \
 	-L${PROJECT_SOURCE_DIR}/../../lib/linux32")
 
+set(LINK_FLAGS "${LINK_FLAGS} -Wl,-z,notext")
+
 set_target_properties(director PROPERTIES
 	OUTPUT_NAME director
 	PREFIX ""

--- a/rehlds/HLTV/Proxy/CMakeLists.txt
+++ b/rehlds/HLTV/Proxy/CMakeLists.txt
@@ -147,6 +147,8 @@ set(LINK_FLAGS "${LINK_FLAGS} \
 	-Wl,-rpath,'$ORIGIN/.' \
 	-L${PROJECT_SOURCE_DIR}/../../lib/linux32")
 
+set(LINK_FLAGS "${LINK_FLAGS} -Wl,-z,notext")
+
 set_target_properties(proxy PROPERTIES
 	OUTPUT_NAME proxy
 	PREFIX ""

--- a/rehlds/filesystem/FileSystem_Stdio/CMakeLists.txt
+++ b/rehlds/filesystem/FileSystem_Stdio/CMakeLists.txt
@@ -99,6 +99,8 @@ target_link_libraries(filesystem_stdio PRIVATE
 	dl
 )
 
+set(LINK_FLAGS "${LINK_FLAGS} -Wl,-z,notext")
+
 set_target_properties(filesystem_stdio PROPERTIES
 	OUTPUT_NAME filesystem_stdio
 	PREFIX ""


### PR DESCRIPTION
## Problem

All i386 shared libraries in this project are intentionally built without `-fPIC` (`POSITION_INDEPENDENT_CODE OFF`). This produces object files with relocations in read-only `.text` sections (text relocations). Modern ld (≥ 2.36) rejects these by default:

```
ld: warning: relocation against '...' in read-only section '.text'
ld: read-only segment has dynamic relocations
collect2: error: ld returned 1 exit status
```

Affected targets: `engine_i486.so`, `filesystem_stdio.so`, `core.so`, `proxy.so`, `director.so`, `demoplayer.so`.

## Fix

Add `-Wl,-z,notext` to each target's `LINK_FLAGS`. This restores the historical linker behaviour that permits text relocations, matching the original intent of `POSITION_INDEPENDENT_CODE OFF`.

## Files changed

- `rehlds/CMakeLists.txt`
- `rehlds/filesystem/FileSystem_Stdio/CMakeLists.txt`
- `rehlds/HLTV/Core/CMakeLists.txt`
- `rehlds/HLTV/Proxy/CMakeLists.txt`
- `rehlds/HLTV/Director/CMakeLists.txt`
- `rehlds/HLTV/DemoPlayer/CMakeLists.txt`