### PR TITLE
dedicated/linux: zero-initialize struct sigaction in Sys_SetupConsole

### DIFF
--- a/rehlds/dedicated/src/sys_linux.cpp
+++ b/rehlds/dedicated/src/sys_linux.cpp
@@ -324,7 +324,7 @@ static void ConsoleCtrlHandler(int signal)
 
 bool Sys_SetupConsole()
 {
-	struct sigaction action;
+	struct sigaction action = {};
 	action.sa_handler = ConsoleCtrlHandler;
 	sigaction(SIGINT, &action, NULL);
 	sigaction(SIGTERM, &action, NULL);


### PR DESCRIPTION
## Summary

`Sys_SetupConsole()` declares `struct sigaction action;` without initialization, leaving `sa_flags` and `sa_restorer` as stack garbage.

If the garbage value of `sa_flags` has `SA_RESTORER` (bit 26, `0x04000000`) set **and** `sa_restorer` is zero (also garbage), the kernel uses a NULL return trampoline for the signal handler. When `ConsoleCtrlHandler` returns via `ret`, it pops `0` as the return address and jumps to it, producing a SIGSEGV at `eip=0x0`.

This was observed reproducibly on Linux i386: both `SIGINT` (`kill -2`) and `SIGTERM` (`kill -15`) crashed the standalone server immediately after the signal was delivered, before the `g_bAppHasBeenTerminated` flag could be checked by the main loop.

gdb analysis confirmed the crash pattern: `eip=0x0`, `eax=2` (the signal number loaded by `ConsoleCtrlHandler`), all other registers zero — consistent with crashing at handler return rather than inside the handler body.

## Fix

```c
- struct sigaction action;
+ struct sigaction action = {};
```

Value-initializing the struct zeroes `sa_flags` and `sa_restorer`, so the kernel uses the vDSO trampoline for signal return as intended.