### PR TITLE
fix: prevent SIGSEGV in SV_RunCmd when speedhack detection drops client mid-frame

### DIFF
--- a/rehlds/engine/sv_user.cpp
+++ b/rehlds/engine/sv_user.cpp
@@ -777,10 +777,7 @@ void SV_RunCmd(usercmd_t* ucmd, int random_seed, qboolean fNetCmd, qboolean fCho
 	float frametime;
 
 #ifdef REHLDS_FIXES
-	// Issue #1198: CheckLimits()/game-DLL callbacks may SV_DropClient() while
-	// SV_ParseMove() still iterates usercmds; edict is then NULL. connected is
-	// always cleared by SV_DropClient (with active/spawned/edict) and stays
-	// TRUE for fakeclients, so it reliably guards all SV_RunCmd call sites.
+	// client could disconnect during CheckLimits or game-DLL callbacks
 	if (!host_client->connected)
 		return;
 #endif // REHLDS_FIXES
@@ -1739,7 +1736,7 @@ void SV_ParseMove(client_t *pSenderClient)
 	}
 
 #ifdef REHLDS_FIXES
-	// Issue #1198: skip post-loop bookkeeping if dropped mid-loop above.
+	// skip if client dropped while executing commands
 	if (!host_client->connected)
 		return;
 

--- a/rehlds/engine/sv_user.cpp
+++ b/rehlds/engine/sv_user.cpp
@@ -776,6 +776,15 @@ void SV_RunCmd(usercmd_t* ucmd, int random_seed, qboolean fNetCmd, qboolean fCho
 	trace_t trace;
 	float frametime;
 
+#ifdef REHLDS_FIXES
+	// Issue #1198: CheckLimits()/game-DLL callbacks may SV_DropClient() while
+	// SV_ParseMove() still iterates usercmds; edict is then NULL. connected is
+	// always cleared by SV_DropClient (with active/spawned/edict) and stays
+	// TRUE for fakeclients, so it reliably guards all SV_RunCmd call sites.
+	if (!host_client->connected)
+		return;
+#endif // REHLDS_FIXES
+
 	if (host_client->ignorecmdtime > realtime)
 	{
 		host_client->cmdtime = (double)ucmd->msec / 1000.0 + host_client->cmdtime;
@@ -1730,6 +1739,10 @@ void SV_ParseMove(client_t *pSenderClient)
 	}
 
 #ifdef REHLDS_FIXES
+	// Issue #1198: skip post-loop bookkeeping if dropped mid-loop above.
+	if (!host_client->connected)
+		return;
+
 	if (numcmds)
 		host_client->lastcmd = cmds[numcmds - 1];
 	else if (numbackup)


### PR DESCRIPTION
## Summary

Fixes a server crash (SIGSEGV) in `SV_RunCmd` that happens when the built-in speedhack detection (added in #1172) kicks a player while `SV_ParseMove()` is still processing the remaining movement commands.

Fixes #1198

## Root cause

`CUserCmdTimeLimiter::CheckLimits()` is called **inside** `SV_RunCmd()` — during the per-command loop in `SV_ParseMove()`. Unlike the existing rate limiters (`CMoveCommandRateLimiter`, `CStringCommandsRateLimiter`), which run **before** the `SV_RunCmd` loop and bail out on `!host_client->connected`, the speedhack detector drops the client mid-loop.

When `CheckLimits()` detects a violation and calls `SV_DropClient()`, the client becomes inactive mid-frame: `SV_DropClient_internal()` clears `connected`/`active`/`spawned` and **nulls `edict`** (`rehlds/engine/host.cpp:498–518`). But `SV_ParseMove()` keeps iterating the remaining commands and calling `SV_RunCmd()`, which dereferences `host_client->edict` (now `NULL`) → SIGSEGV.

```
#0  SV_RunCmd
#1  SV_ParseMove
```
```
=> 0xf5af9406:  mov 0x18c(%eax),%ebx   ; CRASH — null dereference (host_client->edict == NULL)
```

## Fix

Add an early bail at the top of `SV_RunCmd()` when the client is no longer connected (`if (!host_client->connected) return;`). This single guard covers **every** call site:
- the three `SV_RunCmd` loops in `SV_ParseMove()` (drop replay, `net_drop`, new commands),
- the recursive `msec > 50` split (separate `SV_RunCmd` invocations with `fChopped=TRUE`),
- the fakeclient path in `PF_RunPlayerMove_I` (`pr_cmds.cpp`).

Additionally, skip the post-loop bookkeeping in `SV_ParseMove()` (`host_client->lastcmd`, `frame->ping_time`, `sv_player->v.animtime`) for a dropped client so we never touch its stale state.

Both guards sit under `#ifdef REHLDS_FIXES`, consistent with the rest of the speedhack-detection code.

### Why `cl->connected` alone is sufficient

`SV_DropClient_internal()` always clears `connected`, `active`, `spawned` **and** nulls `edict` together, so any one of those flags detects the drop. `connected` is chosen to match the existing rate-limiter bail-out pattern already used in `SV_ParseMove`/`SV_ParseStringCommand` (`sv_user.cpp:1700`, `1892`). Checking `connected` (rather than `active`) also avoids a false-positive on the legitimate `spawned && !active` spawn phase, where `connected` is still `TRUE`, so movement keeps running as before.

## Verification

- Incremental build passes (`engine_i486.so` links; no new warnings — only the pre-existing `libaelf32.a` relocation ones).
- No unit test covers `SV_ParseMove`/`SV_RunCmd` — the CppUnitLite harness tests pure functions only (math/delta/crc/`IsSafeFileToDownload`); `SV_ParseMove` depends on heavy global engine state, so compile-time verification + code-path analysis is the available check.

## Notes

This is the "minimal fix" (option 1 from the issue). The issue also suggests option 2 (defer the punishment to `Rehlds_Security_Frame()` so `SV_DropClient()` is never called mid-frame). I went with option 1 because it matches the existing burst-rate-limiter pattern (which also calls `SV_DropClient` mid-message and bails on `!connected`) and is far less invasive. Option 2 can be layered on top later if desired.